### PR TITLE
feat: use API keys for auth and rate limiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ node_modules/
 *.map
 
 .secrets
+.env
+keys.txt
 
 # Auto-generated firmware index
 firmwares/index.json

--- a/README.md
+++ b/README.md
@@ -19,13 +19,25 @@ See [the documentation](docs/firmware-files.md) for more information on how to a
 
 ## How to use?
 
-Send a HTTP request to one of the API endpoints. Currently these are defined:
+### API Keys
+
+All requests to the API require an API key, provided using the `X-API-Key` HTTP header. API keys are **free for open source** projects. Commercial projects will be charged to cover the server costs.
+
+To request an API key, please [reach out](mailto:info@zwave-js.io) and provide the following information:
+
+-   Project/Company name
+-   Open source / Commercial
+-   Repository URL (open source only)
+-   Approximate no. of requests/hour
+
+Once you have your API key, you can use it to make HTTP requests to the API endpoints. Currently these are defined:
 
 ### API v1, get updates
 
 ```
 POST https://firmware.zwave-js.io/api/v1/updates
 Content-Type: application/json
+X-API-Key: <Your API Key>
 
 {
     "manufacturerId": "0x1234",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "dependencies": {
     "@fastify/helmet": "^9.1.0",
     "@fastify/rate-limit": "^7.0.0",
+    "dotenv": "^16.0.1",
     "fastify": "^4.2.0",
+    "fastify-plugin": "^4.0.0",
     "json-logic-js": "^2.0.2",
     "json5": "^2.2.1",
     "semver": "^7.3.7",

--- a/src/app.route1.test.ts
+++ b/src/app.route1.test.ts
@@ -3,6 +3,8 @@ import supertest from "supertest";
 import { build } from "./app";
 
 test("GET `/` route", async (t) => {
+	process.env.API_REQUIRE_KEY = "false";
+
 	const fastify = await build();
 	t.teardown(() => fastify.close());
 	await fastify.ready();

--- a/src/lib/apiKeys.ts
+++ b/src/lib/apiKeys.ts
@@ -1,0 +1,81 @@
+import type { FastifyRequest } from "fastify";
+import assert from "node:assert";
+import crypto from "node:crypto";
+
+export interface APIKey {
+	id: number;
+	/** The maximum number of requests per hour */
+	rateLimit: number;
+}
+
+// Encoded API key format:
+// aaaabbb000000000
+// aaaa = id (big-endian)
+// bbbb = requests per hour (big-endian)
+// 0000 = reserved for future use
+
+export function encodeAPIKey(apiKey: APIKey): Buffer {
+	const ret = Buffer.alloc(16, 0);
+	ret.writeUInt32BE(apiKey.id, 0);
+	ret.writeUIntBE(apiKey.rateLimit, 4, 3);
+	return ret;
+}
+
+export function decodeAPIKey(apiKey: Buffer): APIKey {
+	assert(apiKey.length === 16);
+
+	const id = apiKey.readUInt32BE(0);
+	const rateLimit = apiKey.readUIntBE(4, 3);
+
+	assert(rateLimit > 0);
+
+	assert(apiKey.subarray(7).every((v) => v === 0));
+
+	return {
+		id,
+		rateLimit,
+	};
+}
+
+export function decryptAPIKey(key: Buffer, apiKeyHex: string): APIKey {
+	// Decrypt API key using AES-256-CBC to check if it is valid.
+	// The API key is encoded as hex with the IV prepended.
+	if (!/^[0-9a-f]{96}$/.test(apiKeyHex)) {
+		throw new Error("Invalid API key");
+	}
+
+	const apiKeyBytes = Buffer.from(apiKeyHex, "hex");
+
+	const iv = apiKeyBytes.subarray(0, 16);
+	const ciphertext = apiKeyBytes.subarray(16);
+	const decipher = crypto.createDecipheriv("aes-256-cbc", key, iv);
+
+	let apiKeyDecoded: APIKey;
+	try {
+		const plaintext = Buffer.concat([
+			decipher.update(ciphertext),
+			decipher.final(),
+		]);
+		apiKeyDecoded = decodeAPIKey(plaintext);
+	} catch (err) {
+		throw new Error("Invalid API key");
+	}
+
+	return apiKeyDecoded;
+}
+
+export function encryptAPIKey(key: Buffer, apiKey: APIKey): string {
+	const iv = crypto.randomBytes(16);
+	const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
+
+	const ciphertext = Buffer.concat([
+		iv,
+		cipher.update(encodeAPIKey(apiKey)),
+		cipher.final(),
+	]);
+	return ciphertext.toString("hex");
+}
+
+export function getAPIKey(req: FastifyRequest): APIKey | undefined {
+	return (req as any).apiKey;
+}

--- a/src/maintenance/makeAPIKey.ts
+++ b/src/maintenance/makeAPIKey.ts
@@ -1,0 +1,26 @@
+// Call this with:
+// ts-node src/maintenance/makeAPIKey.ts <id> <req-per-hour>
+
+// Creates an API key with the given information. In order to work, the
+// API_KEY_ENC_KEY environment variable must be set to the same value as on production
+
+import "dotenv/config";
+
+import { encryptAPIKey } from "../lib/apiKeys";
+
+const id = parseInt(process.argv[2]);
+const limit = parseInt(process.argv[3]);
+if (Number.isNaN(id) || id < 1 || Number.isNaN(limit) || limit < 1) {
+	console.error("Usage: node makeAPIKey.js <id> <req-per-hour>");
+	process.exit(1);
+}
+
+const keyHex = process.env.API_KEY_ENC_KEY;
+if (!keyHex || !/^[0-9a-f]{64}$/.test(keyHex)) {
+	console.error("API_KEY_ENC_KEY env var not provided");
+	process.exit(1);
+}
+const key = Buffer.from(keyHex, "hex");
+
+const apiKey = encryptAPIKey(key, { id, rateLimit: limit });
+console.log(apiKey);

--- a/src/plugins/checkAPIKey.ts
+++ b/src/plugins/checkAPIKey.ts
@@ -1,0 +1,31 @@
+import type { FastifyPluginCallback } from "fastify";
+import fp from "fastify-plugin";
+import { APIKey, decryptAPIKey } from "../lib/apiKeys";
+
+const checkAPIKeyPlugin: FastifyPluginCallback = (instance, opts, done) => {
+	instance.addHook("onRequest", async (request, reply) => {
+		const keyHex = process.env.API_KEY_ENC_KEY;
+		if (!keyHex || !/^[0-9a-f]{64}$/.test(keyHex)) {
+			throw new Error("Setup not complete");
+		}
+		const key = Buffer.from(keyHex, "hex");
+
+		const apiKeyHex = request.headers["x-api-key"];
+		if (typeof apiKeyHex !== "string" || !apiKeyHex) {
+			return reply.code(401).send({ error: "API key not provided" });
+		}
+
+		let apiKey: APIKey;
+		try {
+			apiKey = decryptAPIKey(key, apiKeyHex);
+		} catch (e: any) {
+			return reply.code(401).send({ error: e.message });
+		}
+
+		(request as any).apiKey = apiKey;
+	});
+
+	done();
+};
+
+export default fp(checkAPIKeyPlugin);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,5 @@
+import "dotenv/config";
+
 import { build } from "./app";
 
 async function start() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,10 +465,12 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.30.0
     "@typescript-eslint/parser": ^5.30.0
     ava: ^4.3.0
+    dotenv: ^16.0.1
     eslint: ^8.18.0
     eslint-config-prettier: ^8.5.0
     eslint-plugin-prettier: ^4.1.0
     fastify: ^4.2.0
+    fastify-plugin: ^4.0.0
     json-logic-js: ^2.0.2
     json5: ^2.2.1
     nodemon: ^2.0.18
@@ -1407,6 +1409,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.0.1":
+  version: 16.0.1
+  resolution: "dotenv@npm:16.0.1"
+  checksum: f459ffce07b977b7f15d8cc4ee69cdff77d4dd8c5dc8c85d2d485ee84655352c2415f9dd09d42b5b5985ced3be186130871b34e2f3e2569ebc72fbc2e8096792
+  languageName: node
+  linkType: hard
+
 "duplexer3@npm:^0.1.4":
   version: 0.1.4
   resolution: "duplexer3@npm:0.1.4"
@@ -1778,6 +1787,13 @@ __metadata:
   version: 3.0.1
   resolution: "fastify-plugin@npm:3.0.1"
   checksum: 131ba0a388f777829c3fb0fd5b75cf057688ce6d0ca354fb1ebf829767a8c853b0825762b9185b5200097454df0ede2f3095da2efe1aa1b3736d07f194e6d374
+  languageName: node
+  linkType: hard
+
+"fastify-plugin@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "fastify-plugin@npm:4.0.0"
+  checksum: b929f94e70e3815643842cd50bdfecd26ca2c34ef7a31b1570bd3fe7437174858e9bc4dfa70c2984340d5450c24b830d37fe4789c103ef80565dcc9037ae987a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR implements API keys that have to be provided with each request to limit access to the API and to tune the rate limiter.

API keys are free for open source, and need to be paid for by commercial projects.

This won't be enforced for now, but it will with zwave-js v10