### PR TITLE
fix: correct version number for Enbrighten-GE ZW4203 / 14298 v5.52

### DIFF
--- a/firmwares/enbrighten-ge/ZW4203_14298.json
+++ b/firmwares/enbrighten-ge/ZW4203_14298.json
@@ -10,10 +10,10 @@
 	],
 	"upgrades": [
 		{
-			"version": "5.53",
+			"version": "5.52",
 			"changelog": "1. Original Release Firmware",
-			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/9b5520f5056f7d3fce3fa6adc28bdaf27f8d0a68/zwave/Enbrighten-GE/ZW4203/14298%20-%20Plug-in%20Outdoor%20Smart%20Switch%20V2%2C%20500S/5.53/ZW4203_Enbrighten-GE_14298_5.53.otz",
-			"integrity": "sha256:032fcc96591e0d69b5ed3815e6b803aec25ed3a47be00e26ee05a7d46f221444"
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/074dc4296b248aecefedeb61ec2717c86791ae71/zwave/Enbrighten-GE/ZW4203/14298%20-%20Plug-in%20Outdoor%20Switch%20V2%2C%20500S/5.52/ZW4203_Enbrighten-GE_14298_5.52.otz",
+			"integrity": "sha256:ff4de32b6bff7a0a675f50beefc7e2709c7b31a06f8ea52b0b072b61a308ebbc"
 		}
 	]
 }


### PR DESCRIPTION
Renames ZW4203 / 14298 **v5.53** to **v5.52** to address [issue from jascoproducts/firmware](https://github.com/jascoproducts/firmware/issues/92)