### PR TITLE
fix: move LZW31-SN update to the beta channel

### DIFF
--- a/firmwares/inovelli/LZW31-SN.json
+++ b/firmwares/inovelli/LZW31-SN.json
@@ -11,6 +11,7 @@
 	"upgrades": [
 		{
 			"version": "1.61",
+			"channel": "beta",
 			"changelog": "Fixed - Dimmer sending duplicate reports in certain scenarios while being controlled by certain hubs.",
 			"files": [
 				{


### PR DESCRIPTION
Turns out this is a beta release:
![grafik](https://user-images.githubusercontent.com/17641229/191033518-a75e04cc-5b3f-477f-aa7b-edb48c3f7aa2.png)

We should mark it as such.