### PR TITLE
Add several Zooz device firmware updates

### DIFF
--- a/firmwares/zooz/ZAC36.json
+++ b/firmwares/zooz/ZAC36.json
@@ -1,0 +1,20 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZAC36",
+			"manufacturerId": "0x027a",
+			"productType": "0x0101",
+			"productId": "0x0036"
+		}
+	],
+
+	"upgrades": [
+		{
+			"version": "1.14",
+			"changelog": "* Disabled the battery command class if power bank isn't connected (a battery entity is no longer created automatically after inclusion)",
+			"url": "https://raw.githubusercontent.com/uberchris2/zooz-firmware/main/ZAC36_V1.14_2_1.gbl",
+			"integrity": "sha256:723c4abd597ecfd6dfa414aa47bff80d26e472bc5cb70f2122fb6eb13b277dfb"
+		}
+	]
+}

--- a/firmwares/zooz/ZEN32.json
+++ b/firmwares/zooz/ZEN32.json
@@ -1,0 +1,20 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZEN32",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xa008"
+		}
+	],
+
+	"upgrades": [
+		{
+			"version": "10.20",
+			"changelog": "* Added parameter 23 to disable LED indicator flashing during a setting change\n* Fixed LED indicator command class issue: LED indicators no longer default to the white color when the command is used\n* Fixed bug: with parameter 19 set to 2, the device no longer ignores changes made to parameter 1",
+			"url": "https://raw.githubusercontent.com/uberchris2/zooz-firmware/main/ZEN32_V10R20P01.gbl",
+			"integrity": "sha256:5da4c5d64887d3a91fd85d875cc7e5eb06d71ea7a70bd572e7b7fda86c84ac57"
+		}
+	]
+}

--- a/firmwares/zooz/ZEN73.json
+++ b/firmwares/zooz/ZEN73.json
@@ -1,0 +1,20 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZEN73",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xa003"
+		}
+	],
+
+	"upgrades": [
+		{
+			"version": "10.0",
+			"changelog": "* Removed manual operation delay with scene control disabled\n* Fixed smart bulb behavior after a power outage: the actual status of the relay and the reported status of the relay are both restored correctly now\n* Added the ability to disable programming function from the paddles",
+			"url": "https://raw.githubusercontent.com/uberchris2/zooz-firmware/main/ZEN73_V10_0.gbl",
+			"integrity": "sha256:f2d64309519a8959a779813a37b9028979845974c0d5f66bc5419f64de837c84"
+		}
+	]
+}

--- a/firmwares/zooz/ZEN74.json
+++ b/firmwares/zooz/ZEN74.json
@@ -1,0 +1,20 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZEN74",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xa004"
+		}
+	],
+
+	"upgrades": [
+		{
+			"version": "10.10",
+			"changelog": "* Separated ramp rate into 4 new settings: on physical (parameter 9), on Z-Wave (parameter 28), off physical (parameter 27), and off Z-Wave (parameter 29)\n* Improved night light mode (it takes 1 second instead of 2 to turn the night on via night light mode)\n* Added a new setting to indicate remote dimming duration when using the ZEN74 in association with other dimmers (parameter 30)",
+			"url": "https://raw.githubusercontent.com/uberchris2/zooz-firmware/main/ZEN74_V10R10P01.gbl",
+			"integrity": "sha256:3bb9d4249dc70d5f357a326214e7a8874ee21ca563f2d2fe1571c4dda7901049"
+		}
+	]
+}

--- a/firmwares/zooz/ZSE41.json
+++ b/firmwares/zooz/ZSE41.json
@@ -1,0 +1,20 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZSE41",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xe001"
+		}
+	],
+
+	"upgrades": [
+		{
+			"version": "1.30",
+			"changelog": "US Only",
+			"url": "https://raw.githubusercontent.com/uberchris2/zooz-firmware/main/ZSE41_V01R30P01_US.gbl",
+			"integrity": "sha256:3ccba48a27733442f88eda9b306d2d82b0891fdf1f83a0d730b664e1362ec7ec"
+		}
+	]
+}

--- a/firmwares/zooz/ZSE42.json
+++ b/firmwares/zooz/ZSE42.json
@@ -1,0 +1,20 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZSE42",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xe002"
+		}
+	],
+
+	"upgrades": [
+		{
+			"version": "1.30",
+			"changelog": "US Only",
+			"url": "https://raw.githubusercontent.com/uberchris2/zooz-firmware/main/ZSE42_V01R30P01_US.gbl",
+			"integrity": "sha256:3e8c2069e06d9ab11774beab8a593ff4ec43f25047e197bfa03e0390762be765"
+		}
+	]
+}

--- a/firmwares/zooz/ZSE44.json
+++ b/firmwares/zooz/ZSE44.json
@@ -1,0 +1,20 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZSE44",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xe004"
+		}
+	],
+
+	"upgrades": [
+		{
+			"version": "1.20",
+			"changelog": "n/a",
+			"url": "https://raw.githubusercontent.com/uberchris2/zooz-firmware/main/ZSE44_V01R20P01.gbl",
+			"integrity": "sha256:dbfd710947cc09d749086e3e483d28a6bcd6ddd908a3c1c1aa0e973ead573c0e"
+		}
+	]
+}


### PR DESCRIPTION
Since Zooz provides these updates via email and usually in a zip file, I have hosted the files that I have in a public repo.

Also, a couple of the firmware files are region dependent (US only). There is not presently a variable available to condition these updates on, so I have specified the region in the changelog.