### PR TITLE
Add alternative firmware v0.51 for Enbrighten/GE ZW4002/55258

### DIFF
--- a/firmwares/enbrighten-ge/ZW4002_55258.json
+++ b/firmwares/enbrighten-ge/ZW4002_55258.json
@@ -19,7 +19,7 @@
 			"version": "0.51",
 			"changelog": "1. Added parameter 3 (adjustable LED behavior)\n2. Added parameter 84 (factory reset)\n3. Added experimental parameter 40 (fan speed ramp rate)\n4. Update devkit to 6.84.00",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/a628c1b745b96b187e61c15437d02074302d369a/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/0.51%20(Latest%2C%20Beta)/ZW4002_Enbrighten-GE_55258_0.51.otz",
-			//"integrity": ""
+			"integrity": "sha256:59ae4c4f749d3ad22b1d490e9dd0afe855bbd9914337f37a41beb56d62c638b2"
 		}
 	]
 }

--- a/firmwares/enbrighten-ge/ZW4002_55258.json
+++ b/firmwares/enbrighten-ge/ZW4002_55258.json
@@ -10,21 +10,30 @@
 	],
 	"upgrades": [
 		{
+			"$if": "firmwareVersion >= 5.0",
 			"version": "5.50",
 			"changelog": "1. Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/9b5520f5056f7d3fce3fa6adc28bdaf27f8d0a68/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Smart%20Fan%20Speed%20Control%2C%20500S/5.50/ZW4002_Enbrighten-GE_55258_5.50.otz",
 			"integrity": "sha256:59ae4c4f749d3ad22b1d490e9dd0afe855bbd9914337f37a41beb56d62c638b2"
 		},
 		{
+			"$if": "firmwareVersion === 0.51",
+			"version": "5.50",
+			"changelog": "ENABLE ORIGINAL BEHAVIOR",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/9b5520f5056f7d3fce3fa6adc28bdaf27f8d0a68/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Smart%20Fan%20Speed%20Control%2C%20500S/5.50/ZW4002_Enbrighten-GE_55258_5.50.otz",
+			"integrity": "sha256:59ae4c4f749d3ad22b1d490e9dd0afe855bbd9914337f37a41beb56d62c638b2"
+		},
+		{
+			"$if": "firmwareVersion < 1.0",
 			"version": "0.51",
-			"channel": "beta",
 			"changelog": "1. Added parameter 3 (adjustable LED behavior)\n2. Added parameter 84 (factory reset)\n3. Added experimental parameter 40 (fan speed ramp rate)\n4. Update devkit to 6.84.00",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/a628c1b745b96b187e61c15437d02074302d369a/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/0.51%20(Latest%2C%20Beta)/ZW4002_Enbrighten-GE_55258_0.51.otz",
 			"integrity": "sha256:f35c8babf074bbbc79466ba62cc5e6d11552dfa803c818abdc5624ab9f80e553"
 		},
 		{
-			"$if": "firmwareVersion < 1.0",
+			"$if": "firmwareVersion === 5.50",
 			"version": "0.51",
+			"channel": "beta",
 			"changelog": "1. Added parameter 3 (adjustable LED behavior)\n2. Added parameter 84 (factory reset)\n3. Added experimental parameter 40 (fan speed ramp rate)\n4. Update devkit to 6.84.00",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/a628c1b745b96b187e61c15437d02074302d369a/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/0.51%20(Latest%2C%20Beta)/ZW4002_Enbrighten-GE_55258_0.51.otz",
 			"integrity": "sha256:f35c8babf074bbbc79466ba62cc5e6d11552dfa803c818abdc5624ab9f80e553"

--- a/firmwares/enbrighten-ge/ZW4002_55258.json
+++ b/firmwares/enbrighten-ge/ZW4002_55258.json
@@ -19,7 +19,7 @@
 			"version": "0.51",
 			"changelog": "1. Added parameter 3 (adjustable LED behavior)\n2. Added parameter 84 (factory reset)\n3. Added experimental parameter 40 (fan speed ramp rate)\n4. Update devkit to 6.84.00",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/a628c1b745b96b187e61c15437d02074302d369a/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/0.51%20(Latest%2C%20Beta)/ZW4002_Enbrighten-GE_55258_0.51.otz",
-			"integrity": "sha256:59ae4c4f749d3ad22b1d490e9dd0afe855bbd9914337f37a41beb56d62c638b2"
+			"integrity": "sha256:f35c8babf074bbbc79466ba62cc5e6d11552dfa803c818abdc5624ab9f80e553"
 		}
 	]
 }

--- a/firmwares/enbrighten-ge/ZW4002_55258.json
+++ b/firmwares/enbrighten-ge/ZW4002_55258.json
@@ -17,6 +17,14 @@
 		},
 		{
 			"version": "0.51",
+			"channel": "beta",
+			"changelog": "1. Added parameter 3 (adjustable LED behavior)\n2. Added parameter 84 (factory reset)\n3. Added experimental parameter 40 (fan speed ramp rate)\n4. Update devkit to 6.84.00",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/a628c1b745b96b187e61c15437d02074302d369a/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/0.51%20(Latest%2C%20Beta)/ZW4002_Enbrighten-GE_55258_0.51.otz",
+			"integrity": "sha256:f35c8babf074bbbc79466ba62cc5e6d11552dfa803c818abdc5624ab9f80e553"
+		},
+		{
+			"$if": "firmwareVersion < 1.0",
+			"version": "0.51",
 			"changelog": "1. Added parameter 3 (adjustable LED behavior)\n2. Added parameter 84 (factory reset)\n3. Added experimental parameter 40 (fan speed ramp rate)\n4. Update devkit to 6.84.00",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/a628c1b745b96b187e61c15437d02074302d369a/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/0.51%20(Latest%2C%20Beta)/ZW4002_Enbrighten-GE_55258_0.51.otz",
 			"integrity": "sha256:f35c8babf074bbbc79466ba62cc5e6d11552dfa803c818abdc5624ab9f80e553"

--- a/firmwares/enbrighten-ge/ZW4002_55258.json
+++ b/firmwares/enbrighten-ge/ZW4002_55258.json
@@ -14,6 +14,12 @@
 			"changelog": "1. Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/9b5520f5056f7d3fce3fa6adc28bdaf27f8d0a68/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Smart%20Fan%20Speed%20Control%2C%20500S/5.50/ZW4002_Enbrighten-GE_55258_5.50.otz",
 			"integrity": "sha256:59ae4c4f749d3ad22b1d490e9dd0afe855bbd9914337f37a41beb56d62c638b2"
+		},
+		{
+			"version": "0.51",
+			"changelog": "1. Added parameter 3 (adjustable LED behavior)\n2. Added parameter 84 (factory reset)\n3. Added experimental parameter 40 (fan speed ramp rate)\n4. Update devkit to 6.84.00",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/a628c1b745b96b187e61c15437d02074302d369a/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/0.51%20(Latest%2C%20Beta)/ZW4002_Enbrighten-GE_55258_0.51.otz",
+			//"integrity": ""
 		}
 	]
 }

--- a/firmwares/enbrighten-ge/ZW4002_55258.json
+++ b/firmwares/enbrighten-ge/ZW4002_55258.json
@@ -19,6 +19,7 @@
 		{
 			"$if": "firmwareVersion === 0.51",
 			"version": "5.50",
+			"channel": "beta",
 			"changelog": "ENABLE ORIGINAL BEHAVIOR",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/9b5520f5056f7d3fce3fa6adc28bdaf27f8d0a68/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Smart%20Fan%20Speed%20Control%2C%20500S/5.50/ZW4002_Enbrighten-GE_55258_5.50.otz",
 			"integrity": "sha256:59ae4c4f749d3ad22b1d490e9dd0afe855bbd9914337f37a41beb56d62c638b2"


### PR DESCRIPTION
Adding latest beta firmware for 55258.