### PR TITLE
Add Logic Group ZBA7140 and ZDB5100, firmware 1.8

### DIFF
--- a/firmwares/logic-group/ZBA7140.json
+++ b/firmwares/logic-group/ZBA7140.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "Logic Group",
+			"model": "ZBA7140 Matrix ZBA",
+			"manufacturerId": "0x0234",
+			"productType": "0x0004",
+			"productId": "0x0129"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.8",
+			"changelog": "Bugfix.",
+			"url": "https://logic-group.com/download/6936/",
+			"integrity": "sha256:feb977032263e7e4081c31a45ae65307b9a2dd47852fd83719cc8b25748410df"
+		}
+	]
+}

--- a/firmwares/logic-group/ZDB5100.json
+++ b/firmwares/logic-group/ZDB5100.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "Logic Group",
+			"model": "ZDB5100 Matrix",
+			"manufacturerId": "0x0234",
+			"productType": "0x0003",
+			"productId": "0x0121"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.8",
+			"changelog": "Problem med single-channel associeringer er løst (problem med associering til DIMMY version 1.01).\nSynkron blink med baggrundslys.\nSætte niveau for næste gang lyset tændes.",
+			"url": "https://logic-group.com/download/4235/",
+			"integrity": "sha256:d9b302b3bceb8243e7cc74dcb05c4ca504febb693898bbad90bca09c8e84a4bf"
+		}
+	]
+}

--- a/firmwares/logic-group/ZDB5100.json
+++ b/firmwares/logic-group/ZDB5100.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "1.8",
-			"changelog": "Problem med single-channel associeringer er løst (problem med associering til DIMMY version 1.01).\nSynkron blink med baggrundslys.\nSætte niveau for næste gang lyset tændes.",
+			"changelog": "- Problem med single-channel associeringer er løst (problem med associering til DIMMY version 1.01).\n- Synkron blink med baggrundslys.\n- Sætte niveau for næste gang lyset tændes.",
 			"url": "https://logic-group.com/download/4235/",
 			"integrity": "sha256:d9b302b3bceb8243e7cc74dcb05c4ca504febb693898bbad90bca09c8e84a4bf"
 		}


### PR DESCRIPTION
This adds firmwares for the Danish producer [Logic Group](https://logic-group.com/firmwareopdateringer/), I've initially created files for two products. I have some points below to fix, before handling the rest.

I've written with _Allan Lytken_ from Logic Group, and he confirms that I can redistribute these files.

There are some issues:
- [ ] Logic Group distributes firmwares as zip files with one `.hex` file inside, as I understand it, zwave-js and friends do not unpack zip files
- [ ] Logic Group does not distribute (they used to) all firmwares they've ever made, so I can only do "current"
- [ ] Logic Group _would probably_ maintain these updates themselves. I was told that they cooperate with "all certified controllers" such as Fibaros home center. Is it possible for Z-wave-js to become "certified"? (I don't know which body certifies controllers)