### PR TITLE
feat: use cache API to cache R2 responses, not KV

### DIFF
--- a/src/maintenance/upload.ts
+++ b/src/maintenance/upload.ts
@@ -7,7 +7,7 @@ import type { UploadPayload } from "../lib/uploadSchema";
 import { NodeFS } from "./nodeFS";
 
 const configDir = path.join(__dirname, "../../firmwares");
-const MAX_FILES_PER_REQUEST = 500;
+const MAX_FILES_PER_REQUEST = 50; // limited by no. of subrequests in Cloudflare Workers
 const baseURL = process.env.BASE_URL;
 const adminSecret = process.env.ADMIN_SECRET;
 

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -60,7 +60,7 @@ async function handleUpdateRequest(
 	const { manufacturerId, productType, productId, firmwareVersion } =
 		result.data;
 
-	const filesVersion = await getFilesVersion(env.CONFIG_FILES, env.R2_CACHE);
+	const filesVersion = await getFilesVersion(context, env.CONFIG_FILES);
 
 	if (!filesVersion) {
 		return serverError("Filesystem empty");
@@ -90,7 +90,7 @@ async function handleUpdateRequest(
 		},
 		async () => {
 			const config = await lookupConfig(
-				createCachedR2FS(env.CONFIG_FILES, env.R2_CACHE, filesVersion),
+				createCachedR2FS(context, env.CONFIG_FILES, filesVersion),
 				"/",
 				manufacturerId,
 				productType,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,7 +9,6 @@ export interface CloudflareEnvironment {
 
 	RateLimiter: DurableObjectNamespace;
 
-	R2_CACHE: KVNamespace;
 	API_KEYS: KVNamespace;
 
 	responseHeaders: Record<string, string>;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,7 @@ compatibility_date = "2022-08-28"
 main = "build/worker.js"
 
 kv_namespaces = [
-  { binding = "R2_CACHE", id = "a14d0c5671564efda1e3db0e2f98da60" },
+#   { binding = "R2_CACHE", id = "a14d0c5671564efda1e3db0e2f98da60" },
   { binding = "API_KEYS", id = "7edd033eda014a5ebdd02aed07f31063" }
 ]
 
@@ -42,6 +42,6 @@ watch = true
 cache_persist = true
 env_path = ".env"
 
-kv_persist = true
+# kv_persist = true
 durable_objects_persist = true
 r2_persist = true


### PR DESCRIPTION
Prior to this PR, we used KV to cache files read from R2 in order to achieve lower latency. However this adds unnecessary cost for KV reads, so we now use the Cache API for this instead. 