### PR TITLE
feat: regional updates

### DIFF
--- a/.github/scripts/check-integrity.cjs
+++ b/.github/scripts/check-integrity.cjs
@@ -80,7 +80,12 @@ async function main(param) {
 				file.status === "changed"
 		)
 		.map((file) => file.filename)
-		.filter((filename) => filename.startsWith("firmwares/"));
+		.filter(
+			(filename) =>
+				filename.startsWith("firmwares/") &&
+				filename.endsWith(".json") &&
+				!path.basename(filename).startsWith("_")
+		);
 
 	if (filesToCheck.length === 0) {
 		core.info("No firmware files changed, skipping integrity check");

--- a/README.md
+++ b/README.md
@@ -46,11 +46,26 @@ X-API-Key: <Your API Key>
     "manufacturerId": "0x1234",
     "productType": "0xabcd",
     "productId": "0xcafe",
-    "firmwareVersion": "1.6"
+    "firmwareVersion": "1.6",
+    "region": "europe"
 }
 ```
 
 The `firmwareVersion` field may also contain a patch version, e.g. `1.6.1`. When no patch version is provided, it will be assumed to be `0`, so `1.6` is equivalent to `1.6.0`.
+
+The `region` field is optional and may be omitted. If provided, it must be one of the following (case insensitive):
+- `"europe"`
+- `"usa"`
+- `"australia/new zealand"`
+- `"hong kong"`
+- `"india"`
+- `"israel"`
+- `"russia"`
+- `"china"`
+- `"japan"`
+- `"korea"`
+
+Firmware updates that belong to a specific region will only be returned if the `region` field is provided and a match.
 
 **Example response:**
 

--- a/README.md
+++ b/README.md
@@ -200,25 +200,29 @@ X-API-Key: <Your API Key>
     "manufacturerId": "0x1234",
     "productType": "0xabcd",
     "productId": "0xcafe",
-    "firmwareVersion": "1.6"
+    "firmwareVersion": "1.6",
+    "region": "europe"
 }
 ```
 
 Changes compared to v2:
 
--   Adds the `region` field to the response, which can be one of these values:
--   `"europe"`
--   `"usa"`
--   `"australia/new zealand"`
--   `"hong kong"`
--   `"india"`
--   `"israel"`
--   `"russia"`
--   `"china"`
--   `"japan"`
--   `"korea"`
+-   Adds the **optional** `region` field to both the request and the response, which can be one of these values:
+    -   `"europe"`
+    -   `"usa"`
+    -   `"australia/new zealand"`
+    -   `"hong kong"`
+    -   `"india"`
+    -   `"israel"`
+    -   `"russia"`
+    -   `"china"`
+    -   `"japan"`
+    -   `"korea"`
 
-The `region` field is optional and may be omitted. If present, applications **must** ensure that the region of the firmware update matches the region of the device. Firmware updates without this field are assumed to be region-agnostic.
+If the `region` field is present in the request, the response will only contain updates for that region, or updates without a specified region (which are assumed to be region-agnostic).
+If no `region` is specified in the request, the response will only contain updates without a specified region.
+
+Previous API versions will ignore the `region` field in the request and will not return updates with a specified region.
 
 **Example response:**
 
@@ -238,21 +242,6 @@ The `region` field is optional and may be omitted. If present, applications **mu
         "downgrade": false,
         "normalizedVersion": "1.7.0",
         "region": "europe"
-    },
-    {
-        "version": "1.7",
-        "changelog": "China Version:\n* Fixed some bugs\n*Added more bugs",
-        "channel": "stable",
-        "files": [
-            {
-                "target": 0,
-                "integrity": "sha256:cd19da525f20096a817197bf263f3fdbe6485f00ec7354b691171358ebb9f1a1",
-                "url": "https://example.com/firmware/1.7-cn.otz"
-            }
-        ],
-        "downgrade": false,
-        "normalizedVersion": "1.7.0",
-        "region": "china"
     }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -46,26 +46,11 @@ X-API-Key: <Your API Key>
     "manufacturerId": "0x1234",
     "productType": "0xabcd",
     "productId": "0xcafe",
-    "firmwareVersion": "1.6",
-    "region": "europe"
+    "firmwareVersion": "1.6"
 }
 ```
 
 The `firmwareVersion` field may also contain a patch version, e.g. `1.6.1`. When no patch version is provided, it will be assumed to be `0`, so `1.6` is equivalent to `1.6.0`.
-
-The `region` field is optional and may be omitted. If provided, it must be one of the following (case insensitive):
-- `"europe"`
-- `"usa"`
-- `"australia/new zealand"`
-- `"hong kong"`
-- `"india"`
-- `"israel"`
-- `"russia"`
-- `"china"`
-- `"japan"`
-- `"korea"`
-
-Firmware updates that belong to a specific region will only be returned if the `region` field is provided and a match.
 
 **Example response:**
 
@@ -194,6 +179,102 @@ type APIv2_Response = {
     version: string;
     changelog: string;
     channel: "stable" | "beta";
+    files: {
+        target: number;
+        url: string;
+        integrity: string;
+    }[];
+    downgrade: boolean;
+    normalizedVersion: string;
+}[];
+```
+
+### API v3, get updates
+
+```
+POST https://firmware.zwave-js.io/api/v3/updates
+Content-Type: application/json
+X-API-Key: <Your API Key>
+
+{
+    "manufacturerId": "0x1234",
+    "productType": "0xabcd",
+    "productId": "0xcafe",
+    "firmwareVersion": "1.6"
+}
+```
+
+Changes compared to v2:
+
+-   Adds the `region` field to the response, which can be one of these values:
+-   `"europe"`
+-   `"usa"`
+-   `"australia/new zealand"`
+-   `"hong kong"`
+-   `"india"`
+-   `"israel"`
+-   `"russia"`
+-   `"china"`
+-   `"japan"`
+-   `"korea"`
+
+The `region` field is optional and may be omitted. If present, applications **must** ensure that the region of the firmware update matches the region of the device. Firmware updates without this field are assumed to be region-agnostic.
+
+**Example response:**
+
+```json
+[
+    {
+        "version": "1.7",
+        "changelog": "EU Version:\n* Fixed some bugs\n*Added more bugs",
+        "channel": "stable",
+        "files": [
+            {
+                "target": 0,
+                "integrity": "sha256:cd19da525f20096a817197bf263f3fdbe6485f00ec7354b691171358ebb9f1a1",
+                "url": "https://example.com/firmware/1.7-eu.otz"
+            }
+        ],
+        "downgrade": false,
+        "normalizedVersion": "1.7.0",
+        "region": "europe"
+    },
+    {
+        "version": "1.7",
+        "changelog": "China Version:\n* Fixed some bugs\n*Added more bugs",
+        "channel": "stable",
+        "files": [
+            {
+                "target": 0,
+                "integrity": "sha256:cd19da525f20096a817197bf263f3fdbe6485f00ec7354b691171358ebb9f1a1",
+                "url": "https://example.com/firmware/1.7-cn.otz"
+            }
+        ],
+        "downgrade": false,
+        "normalizedVersion": "1.7.0",
+        "region": "china"
+    }
+]
+```
+
+**Response type definition:**
+
+```ts
+type APIv3_Response = {
+    version: string;
+    changelog: string;
+    channel: "stable" | "beta";
+    region?:
+        | "europe"
+        | "usa"
+        | "australia/new zealand"
+        | "hong kong"
+        | "india"
+        | "israel"
+        | "russia"
+        | "china"
+        | "japan"
+        | "korea";
     files: {
         target: number;
         url: string;

--- a/firmwares/_example.json
+++ b/firmwares/_example.json
@@ -75,6 +75,17 @@
 					"integrity": "..."
 				}
 			]
+		},
+		{
+			"version": "1.7",
+			"changelog": "Bugfixes for EU only",
+
+			// Updates can be limited to a specific region.
+			// In this case, the application must ensure that the update's region matches the device.
+			"region": "europe",
+
+			"url": "https://example.com/firmware/1.7-eu.otz",
+			"integrity": "sha256:cd19da525f20096a817197bf263f3fdbe6485f00ec7354b691171358ebb9f1a1"
 		}
 		// ... more firmware updates for the same file
 	]

--- a/firmwares/iblinds/iblinds_V3-1.json
+++ b/firmwares/iblinds/iblinds_V3-1.json
@@ -11,6 +11,7 @@
 	"upgrades": [
 		{
 			"version": "3.12",
+			"region": "usa",
 			"changelog": "Current Spike Detection Large/Heavy Blind - In the previous version we added motor protection that stopped the motor when the max current was reached. Added a spike detection to prevent false-positive this keeps large/heavy blinds from stopping before the target location has been reached.\nDuration Interrupt – Corrected duration interrupt problem. If a set command is sent while the blind is still processing a set command with a duration value the motor will now cancel the current duration command and handle the new command.",
 			"url": "https://support.myiblinds.com/wp-content/uploads/2021/09/iBlinds_v3.12_US.gbl",
 			"integrity": "sha256:52206d165bc44f869ec18807a357a0efba15d68548250b2a992f676cade6686e"

--- a/firmwares/iblinds/iblinds_V3.json
+++ b/firmwares/iblinds/iblinds_V3.json
@@ -11,6 +11,7 @@
 	"upgrades": [
 		{
 			"version": "3.7",
+			"region": "usa",
 			"changelog": "Current Spike Detection Large/Heavy Blind – In the previous version we added motor protection that stopped the motor when the max current was reached. Added a spike detection to prevent false-positive this keeps large/heavy blinds from stopping before the target location has been reached.\nDuration Interrupt – Corrected duration interrupt problem. If a set command is sent while the blind is still processing a set command with a duration value the motor will now cancel the current duration command and handle the new command.",
 			"url": "https://support.myiblinds.com/wp-content/uploads/2021/09/iBlinds_v3.07_US.gbl",
 			"integrity": "sha256:3262c5bfb2c93981fb07ce86aa4f73b073beea94b47f27e0b98dc91766a79849"

--- a/schemas/firmware.json
+++ b/schemas/firmware.json
@@ -45,10 +45,6 @@
 								},
 								"required": ["min", "max"],
 								"additionalProperties": false
-							},
-							"region": {
-								"$ref": "#/definitions/region",
-								"description": "Optionally limit the firmware updates to the given region"
 							}
 						},
 						"required": [
@@ -82,6 +78,9 @@
 									"channel": {
 										"$ref": "#/definitions/releaseChannel"
 									},
+									"region": {
+										"$ref": "#/definitions/region"
+									},
 									"target": {
 										"$ref": "#/definitions/firmwareTarget"
 									},
@@ -114,6 +113,9 @@
 									},
 									"channel": {
 										"$ref": "#/definitions/releaseChannel"
+									},
+									"region": {
+										"$ref": "#/definitions/region"
 									},
 									"files": {
 										"type": "array",
@@ -171,7 +173,8 @@
 				"china",
 				"japan",
 				"korea"
-			]
+			],
+			"description": "Which region this update is for"
 		},
 		"integrity": {
 			"type": "string",

--- a/schemas/firmware.json
+++ b/schemas/firmware.json
@@ -45,6 +45,10 @@
 								},
 								"required": ["min", "max"],
 								"additionalProperties": false
+							},
+							"region": {
+								"$ref": "#/definitions/region",
+								"description": "Optionally limit the firmware updates to the given region"
 							}
 						},
 						"required": [
@@ -154,6 +158,20 @@
 		"firmwareVersion": {
 			"type": "string",
 			"pattern": "^([0-9]|[1-9][0-9]|[1-2][0-9][0-9])\\.([0-9]|[1-9][0-9]|[1-2][0-9][0-9])$"
+		},
+		"region": {
+			"enum": [
+				"europe",
+				"usa",
+				"australia/new zealand",
+				"hong kong",
+				"india",
+				"israel",
+				"russia",
+				"china",
+				"japan",
+				"korea"
+			]
 		},
 		"integrity": {
 			"type": "string",

--- a/src/apiDefinitions.ts
+++ b/src/apiDefinitions.ts
@@ -1,9 +1,13 @@
 import { z } from "zod";
-import { firmwareVersionSchema, UpgradeInfo } from "./lib/configSchema";
+import {
+	firmwareVersionSchema,
+	regionSchema,
+	UpgradeInfo,
+} from "./lib/configSchema";
 import { ExpandRecursively, hexKeyRegex4Digits } from "./lib/shared";
 
-/** The request schema for API versions 1...3 */
-export const APIv1v3_RequestSchema = z.object({
+/** The request schema for API versions 1...2 */
+export const APIv1v2_RequestSchema = z.object({
 	manufacturerId: z.string().regex(hexKeyRegex4Digits, {
 		message: "Must be a hexadecimal number with 4 digits",
 	}),
@@ -15,6 +19,13 @@ export const APIv1v3_RequestSchema = z.object({
 	}),
 	firmwareVersion: firmwareVersionSchema,
 });
+
+/** The request schema for API version 3 */
+export const APIv3_RequestSchema = APIv1v2_RequestSchema.merge(
+	z.object({
+		region: regionSchema.optional(),
+	})
+);
 
 export interface APIv1v3_UpgradeMeta {
 	downgrade: boolean;

--- a/src/apiDefinitions.ts
+++ b/src/apiDefinitions.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { firmwareVersionSchema, UpgradeInfo } from "./lib/configSchema";
 import { ExpandRecursively, hexKeyRegex4Digits } from "./lib/shared";
 
-export const APIv1v2_RequestSchema = z.object({
+/** The request schema for API versions 1...3 */
+export const APIv1v3_RequestSchema = z.object({
 	manufacturerId: z.string().regex(hexKeyRegex4Digits, {
 		message: "Must be a hexadecimal number with 4 digits",
 	}),
@@ -15,14 +16,18 @@ export const APIv1v2_RequestSchema = z.object({
 	firmwareVersion: firmwareVersionSchema,
 });
 
-export interface APIv1v2_UpgradeMeta {
+export interface APIv1v3_UpgradeMeta {
 	downgrade: boolean;
 	normalizedVersion: string;
 }
 
-export type APIv1_UpgradeInfo = Omit<UpgradeInfo, "channel"> &
-	APIv1v2_UpgradeMeta;
+export type APIv1_UpgradeInfo = Omit<UpgradeInfo, "channel" | "region"> &
+	APIv1v3_UpgradeMeta;
 export type APIv1_Response = ExpandRecursively<APIv1_UpgradeInfo[]>;
 
-export type APIv2_UpgradeInfo = UpgradeInfo & APIv1v2_UpgradeMeta;
+export type APIv2_UpgradeInfo = Omit<UpgradeInfo, "region"> &
+	APIv1v3_UpgradeMeta;
 export type APIv2_Response = ExpandRecursively<APIv2_UpgradeInfo[]>;
+
+export type APIv3_UpgradeInfo = UpgradeInfo & APIv1v3_UpgradeMeta;
+export type APIv3_Response = ExpandRecursively<APIv3_UpgradeInfo[]>;

--- a/src/lib/configSchema.ts
+++ b/src/lib/configSchema.ts
@@ -7,6 +7,19 @@ export const firmwareVersionSchema = z
 	.string()
 	.refine(isFirmwareVersion, "Is not a valid firmware version");
 
+export const regionSchema = z.enum([
+	"europe",
+	"usa",
+	"australia/new zealand",
+	"hong kong",
+	"india",
+	"israel",
+	"russia",
+	"china",
+	"japan",
+	"korea",
+]);
+
 const deviceSchema = z.object({
 	brand: z.string().min(1),
 	model: z.string().min(1),
@@ -51,20 +64,7 @@ const upgradeBaseSchema = z.object({
 	version: firmwareVersionSchema,
 	changelog: z.string().min(1),
 	channel: z.enum(["stable", "beta"]).optional().default("stable"),
-	region: z
-		.enum([
-			"europe",
-			"usa",
-			"australia/new zealand",
-			"hong kong",
-			"india",
-			"israel",
-			"russia",
-			"china",
-			"japan",
-			"korea",
-		])
-		.optional(),
+	region: regionSchema.optional(),
 });
 
 const upgradeSchemaMultiple = upgradeBaseSchema.merge(

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,10 +1,11 @@
 import { withDurables } from "itty-durable";
 import { json, type ThrowableRouter } from "itty-router-extras";
 import {
-	APIv1v2_RequestSchema,
+	APIv1v3_RequestSchema,
 	APIv1_Response,
 	APIv2_Response,
-} from "../apiV1V2";
+	APIv3_Response,
+} from "../apiDefinitions";
 import type { RateLimiterProps } from "../durable_objects/RateLimiter";
 import { withCache } from "../lib/cache";
 import { lookupConfig } from "../lib/config";
@@ -53,7 +54,7 @@ async function handleUpdateRequest(
 	context: ExecutionContext,
 	resultTransform: ResultTransform
 ) {
-	const result = await APIv1v2_RequestSchema.safeParseAsync(req.content);
+	const result = await APIv1v3_RequestSchema.safeParseAsync(req.content);
 	if (!result.success) {
 		return clientError(result.error.format() as any);
 	}
@@ -158,10 +159,12 @@ export default function register(router: ThrowableRouter): void {
 					// API version 1 does not support release channels
 					return (
 						upgrades
-							// Keep only stable releases
+							// Keep only stable releases (channel is v2 only)
 							.filter((u) => u.channel === "stable")
-							// Remove the channel property
-							.map(({ channel, ...u }) => {
+							// Keep only updates without a region (v3 only)
+							.filter((u) => !u.region)
+							// Remove the channel and region property
+							.map(({ channel, region, ...u }) => {
 								// Add missing fields to the returned objects
 								const downgrade =
 									compareVersions(
@@ -189,6 +192,41 @@ export default function register(router: ThrowableRouter): void {
 				env,
 				context,
 				(upgrades, { firmwareVersion }): APIv2_Response => {
+					return (
+						upgrades
+							// Keep only updates without a region (v3 only)
+							.filter((u) => !u.region)
+							// Remove the region property
+							.map(({ region, ...u }) => {
+								// Add missing fields to the returned objects
+								const downgrade =
+									compareVersions(
+										u.version,
+										firmwareVersion
+									) < 0;
+								let normalizedVersion = padVersion(u.version);
+								if (u.channel === "beta")
+									normalizedVersion += "-beta";
+
+								return {
+									...u,
+									downgrade,
+									normalizedVersion,
+								};
+							})
+					);
+				}
+			)
+	);
+
+	router.post(
+		"/api/v3/updates",
+		(req: RequestWithProps<[ContentProps]>, env, context) =>
+			handleUpdateRequest(
+				req,
+				env,
+				context,
+				(upgrades, { firmwareVersion }): APIv3_Response => {
 					return upgrades.map((u) => {
 						// Add missing fields to the returned objects
 						const downgrade =


### PR DESCRIPTION
With this change, we have the capability to specify which region an update belongs to. Since filtering updates by region requires region information from the client, this feature is opt-in through the new `/v3` API endpoint. The v1 and v2 endpoints will not return any updates which have a region specified. The v3 endpoint will only return updates without any region information (considered applicable to all regions) as well as updates matching the provided region.

fixes: #41