### PR TITLE
Import Leviton firmware from upstream.

### DIFF
--- a/firmwares/leviton/DK1KD.json
+++ b/firmwares/leviton/DK1KD.json
@@ -1,0 +1,21 @@
+{
+    "devices": [
+        {
+			// https://products.z-wavealliance.org/products/1956?selectedFrequencyId=2
+            "brand": "Leviton",
+            "model": "DK1KD",
+            "manufacturerId": "0x001d",
+            "productType": "0x3301",
+			"productId": "0x0001",
+		}
+    ],
+	"upgrades": [
+		{
+			"version": "1.22",
+			"changelog": "Latest Leviton Firmware",
+			"target": 0,
+			"url": "https://hubconnecteddecorasmart.leviton.com/hc/en-us/article_attachments/7150650664091/DZ1KD_v1_22.ota",
+			"integrity": "sha256:974c4cede0176bc21478faa77394de9e1d1707bed233134dd1eb080f13459f33",
+		}
+	]
+}

--- a/firmwares/leviton/DZ15S.json
+++ b/firmwares/leviton/DZ15S.json
@@ -1,0 +1,21 @@
+{
+    "devices": [
+        {
+			// https://products.z-wavealliance.org/products/1957?selectedFrequencyId=2
+            "brand": "Leviton",
+            "model": "DZ15S",
+            "manufacturerId": "0x001d",
+            "productType": "0x3401",
+			"productId": "0x0001",
+		}
+    ],
+	"upgrades": [
+		{
+			"version": "1.23",
+			"changelog": "Latest Leviton Firmware",
+			"target": 0,
+			"url": "https://hubconnecteddecorasmart.leviton.com/hc/en-us/article_attachments/7150678400027/DZ15S_v1_23.ota",
+			"integrity": "sha256:a7be23590211edb1cc264edf2209d355786317d4d6eb04708609425402bff71d",
+		}
+	]
+}

--- a/firmwares/leviton/DZ6HD.json
+++ b/firmwares/leviton/DZ6HD.json
@@ -1,0 +1,21 @@
+{
+    "devices": [
+        {
+			// https://products.z-wavealliance.org/products/1910?selectedFrequencyId=2
+            "brand": "Leviton",
+            "model": "DZ6HD",
+            "manufacturerId": "0x001d",
+            "productType": "0x3201",
+			"productId": "0x0001",
+		}
+    ],
+	"upgrades": [
+		{
+			"version": "1.22",
+			"changelog": "Latest Leviton Firmware",
+			"target": 0,
+			"url": "https://hubconnecteddecorasmart.leviton.com/hc/en-us/article_attachments/7150650614043/DZ6HD_v1_22.ota",
+			"integrity": "sha256:502141714eeb1868e85f0545f5b86f4639ee04de4c984c48202ba20b7192c79a",
+		}
+	]
+}

--- a/firmwares/leviton/DZPA1.json
+++ b/firmwares/leviton/DZPA1.json
@@ -1,0 +1,21 @@
+{
+    "devices": [
+        {
+			// https://products.z-wavealliance.org/products/1959?selectedFrequencyId=2
+            "brand": "Leviton",
+            "model": "DZPA1",
+            "manufacturerId": "0x001d",
+            "productType": "0x3601",
+			"productId": "0x0001",
+		}
+    ],
+	"upgrades": [
+		{
+			"version": "1.23",
+			"changelog": "Latest Leviton Firmware",
+			"target": 0,
+			"url": "https://hubconnecteddecorasmart.leviton.com/hc/en-us/article_attachments/7150679340315/DZPA1_v1_23.ota",
+			"integrity": "sha256:04b1d208553ea12a0361e293333835c200cb18e879ec4c4e877b5af7dcf182cc",
+		}
+	]
+}

--- a/firmwares/leviton/DZPD3.json
+++ b/firmwares/leviton/DZPD3.json
@@ -1,0 +1,21 @@
+{
+    "devices": [
+        {
+			// https://products.z-wavealliance.org/products/1958?selectedFrequencyId=2
+            "brand": "Leviton",
+            "model": "DZPD3",
+            "manufacturerId": "0x001d",
+            "productType": "0x3501",
+			"productId": "0x0001",
+		}
+    ],
+	"upgrades": [
+		{
+			"version": "1.22",
+			"changelog": "Latest Leviton Firmware",
+			"target": 0,
+			"url": "https://hubconnecteddecorasmart.leviton.com/hc/en-us/article_attachments/7150704823963/DZPD3_v1_22.ota",
+			"integrity": "sha256:e8c5537eb92462bfdfa5730bac03ae37f4191ad88a846834ed7f0e078daa932f",
+		}
+	]
+}


### PR DESCRIPTION
Import Leviton firmware updates from https://hubconnecteddecorasmart.leviton.com/hc/en-us/articles/7151993826075-Updating-Decora-Smart-Z-Wave-Using-Home-Assistant .

I own the DZ6HD and DZ15S and have successfully updated the firmware on both. I don't own the others, but have verified the device IDs with the Z-Wave alliance pages, linked from each device file.