### PR TITLE
feat: add Inovelli LZW31 v1.52 (beta) and v1.57

### DIFF
--- a/firmwares/inovelli/LZW31.json
+++ b/firmwares/inovelli/LZW31.json
@@ -12,7 +12,7 @@
 		{
 			"version": "1.52",
 			"channel": "beta",
-			"changelog": "Modified Smart Bulb Mode so that the output can only be turned off by sending a BasicSet(0x00). Fixed: Solve the problem that the power measured by the light is 5W when the load is not connected (caused by inaccurate power measurement at extremely low power consumption). Feature: Added config button scenes and basic scenes. This version only (Not enough storage space going further).",
+			"changelog": "- Modified Smart Bulb Mode so that the output can only be turned off by sending a Basic Set (0x00).\n- Fixed: Solve the problem that the power measured by the light is 5W when the load is not connected (caused by inaccurate power measurement at extremely low power consumption).\n- Feature: Added config button scenes and basic scenes. This version only (Not enough storage space going further).",
 			"files": [
 				{
 					"target": 0,
@@ -29,7 +29,7 @@
 		{
 			"version": "1.57",
 			"channel": "stable",
-			"changelog": "Fixed - Optimization of Aux mode in neutral setting. Fixed - The inoperative issue after changing parameter 8 from high value to low value.",
+			"changelog": "- Fixed - Optimization of Aux mode in neutral setting.\n- Fixed - The inoperative issue after changing parameter 8 from high value to low value.",
 			"files": [
 				{
 					"target": 0,
@@ -39,7 +39,6 @@
 				{
 					"target": 1,
 					"url": "https://files.inovelli.com/firmware/LZW31/1.57/LZW31_1.44.bin",
-
 					"integrity": "sha256:d7257a646f53d88b4f1ce159354b8f8475f9338030641621f9a6861ca172dc23"
 				}
 			]

--- a/firmwares/inovelli/LZW31.json
+++ b/firmwares/inovelli/LZW31.json
@@ -1,0 +1,48 @@
+{
+	"devices": [
+		{
+			"brand": "Inovelli",
+			"model": "LZW31",
+			"manufacturerId": "0x031e",
+			"productType": "0x0003",
+			"productId": "0x0001"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.56",
+			"channel": "beta",
+			"changelog": "Fixed - Further optimization of Aux switch support in neutral and non-neutral.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://files.inovelli.com/firmware/LZW31/Beta/1.56/LZW31_1.56.otz",
+					"integrity": "sha256:4567da33054658cc52d2df43447c74b361813495ece3429d44a8c9bcd3106bb2"
+				},
+				{
+					"target": 1,
+					"url": "https://files.inovelli.com/firmware/LZW31/1.57/LZW31_1.44.bin",
+					"integrity": "sha256:d7257a646f53d88b4f1ce159354b8f8475f9338030641621f9a6861ca172dc23"
+				}
+			]
+		},
+		{
+			"version": "1.57",
+			"channel": "stable",
+			"changelog": "Fixed - Optimization of Aux mode in neutral setting. Fixed - The inoperative issue after changing parameter 8 from high value to low value.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://files.inovelli.com/firmware/LZW31/1.57/LZW31_1.57.otz",
+					"integrity": "sha256:4567da33054658cc52d2df43447c74b361813495ece3429d44a8c9bcd3106bb2"
+				},
+				{
+					"target": 1,
+					"url": "https://files.inovelli.com/firmware/LZW31/1.57/LZW31_1.44.bin",
+
+					"integrity": "sha256:d7257a646f53d88b4f1ce159354b8f8475f9338030641621f9a6861ca172dc23"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/inovelli/LZW31.json
+++ b/firmwares/inovelli/LZW31.json
@@ -10,23 +10,6 @@
 	],
 	"upgrades": [
 		{
-			"version": "1.56",
-			"channel": "beta",
-			"changelog": "Fixed - Further optimization of Aux switch support in neutral and non-neutral.",
-			"files": [
-				{
-					"target": 0,
-					"url": "https://files.inovelli.com/firmware/LZW31/Beta/1.56/LZW31_1.56.otz",
-					"integrity": "sha256:4567da33054658cc52d2df43447c74b361813495ece3429d44a8c9bcd3106bb2"
-				},
-				{
-					"target": 1,
-					"url": "https://files.inovelli.com/firmware/LZW31/1.57/LZW31_1.44.bin",
-					"integrity": "sha256:d7257a646f53d88b4f1ce159354b8f8475f9338030641621f9a6861ca172dc23"
-				}
-			]
-		},
-		{
 			"version": "1.52",
 			"channel": "beta",
 			"changelog": "Modified Smart Bulb Mode so that the output can only be turned off by sending a BasicSet(0x00). Fixed: Solve the problem that the power measured by the light is 5W when the load is not connected (caused by inaccurate power measurement at extremely low power consumption). Feature: Added config button scenes and basic scenes. This version only (Not enough storage space going further).",

--- a/firmwares/inovelli/LZW31.json
+++ b/firmwares/inovelli/LZW31.json
@@ -17,7 +17,7 @@
 				{
 					"target": 0,
 					"url": "https://files.inovelli.com/firmware/LZW31/Beta/1.52/LZW31_1.52.otz",
-					"integrity": "sha256:e52ec035ba3111823fefbd8459b2ac2da19779fb87eeb9536e95e6e6f9a447b2"
+					"integrity": "sha256:1a15dbc0143473b9af8e9bb7a8540e20b67d867362ff90b11e5dd1286f83c741"
 				},
 				{
 					"target": 1,
@@ -34,7 +34,7 @@
 				{
 					"target": 0,
 					"url": "https://files.inovelli.com/firmware/LZW31/1.57/LZW31_1.57.otz",
-					"integrity": "sha256:4567da33054658cc52d2df43447c74b361813495ece3429d44a8c9bcd3106bb2"
+					"integrity": "sha256:a994cb634cd0a69bed095a2586c192cde012343fd99088f26bd7b5d0b94472d7"
 				},
 				{
 					"target": 1,

--- a/firmwares/inovelli/LZW31.json
+++ b/firmwares/inovelli/LZW31.json
@@ -27,6 +27,23 @@
 			]
 		},
 		{
+			"version": "1.52",
+			"channel": "beta",
+			"changelog": "Modified Smart Bulb Mode so that the output can only be turned off by sending a BasicSet(0x00). Fixed: Solve the problem that the power measured by the light is 5W when the load is not connected (caused by inaccurate power measurement at extremely low power consumption). Feature: Added config button scenes and basic scenes. This version only (Not enough storage space going further).",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://files.inovelli.com/firmware/LZW31/Beta/1.52/LZW31_1.52.otz",
+					"integrity": "sha256:e52ec035ba3111823fefbd8459b2ac2da19779fb87eeb9536e95e6e6f9a447b2"
+				},
+				{
+					"target": 1,
+					"url": "https://files.inovelli.com/firmware/LZW31/Beta/1.52/LZW31_1.43.bin",
+					"integrity": "sha256:f749d093281ca60459c1f49bcac6d1bfa4745f006f7e3556798e81a7d70e16a5"
+				}
+			]
+		},		
+		{
 			"version": "1.57",
 			"channel": "stable",
 			"changelog": "Fixed - Optimization of Aux mode in neutral setting. Fixed - The inoperative issue after changing parameter 8 from high value to low value.",


### PR DESCRIPTION
[reference manufacturers website for firmware details](https://support.inovelli.com/portal/en/kb/articles/firmware-change-log-lzw31-dimmer-switch-black-series#Beta)