### PR TITLE
change Ultraloq Z-Wave Lock firmware from beta channel to stable

### DIFF
--- a/firmwares/ultraloq/U-BOLT-PRO-ZWAVE.json
+++ b/firmwares/ultraloq/U-BOLT-PRO-ZWAVE.json
@@ -12,7 +12,7 @@
 		{
 			"version": "1.5",
 			"channel": "stable",
-			"changelog": "-Fixed door state issue",
+			"changelog": "Fixed door state issue",
 			"files": [
 				{
 					"target": 0,

--- a/firmwares/ultraloq/U-BOLT-PRO-ZWAVE.json
+++ b/firmwares/ultraloq/U-BOLT-PRO-ZWAVE.json
@@ -11,8 +11,8 @@
 	"upgrades": [
 		{
 			"version": "1.5",
-			"channel": "beta",
-			"changelog": "Fixed door state issue",
+			"channel": "stable",
+			"changelog": "-Fixed door state issue",
 			"files": [
 				{
 					"target": 0,


### PR DESCRIPTION
change z-wave firmware from beta channel to stable
-Fixed door state issue.
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->