### PR TITLE
Add Aeotec ZW111-C EU firmware version 2.4

### DIFF
--- a/firmwares/aeotec/ZW111-C.json
+++ b/firmwares/aeotec/ZW111-C.json
@@ -17,8 +17,8 @@
 			"files": [
 				{
 					"target": 0,
-					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6177502038",
-					"integrity": "sha256:e24aa361dd4d217550acbc1011db102ad42a3dab96d8b93b2c193f3cb919b4a7"
+					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6189873103",
+					"integrity": "sha256:165c1a652eeaf96c0d28370cd8480bf9bb3206dc9321e3d663b0de9d199a3082"
 				}
 			]
 		}

--- a/firmwares/aeotec/ZW111-C.json
+++ b/firmwares/aeotec/ZW111-C.json
@@ -18,7 +18,7 @@
 				{
 					"target": 0,
 					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6189873103",
-					"integrity": "sha256:165c1a652eeaf96c0d28370cd8480bf9bb3206dc9321e3d663b0de9d199a3082"
+					"integrity": "sha256:aba71a9c6f2065b8fc5e683b81ebeea7cfbb1f66342be969d48eb5b671479b7e"
 				}
 			]
 		}

--- a/firmwares/aeotec/ZW111-C.json
+++ b/firmwares/aeotec/ZW111-C.json
@@ -1,0 +1,26 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW111-C",
+			"manufacturerId": "0x0086",
+			"productType": "0x0003", //EU
+			"productId": "0x006f",
+		}
+	],
+	"upgrades": [ //firmware 2.04
+		{
+			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 2.4",
+			"version": "2.4",
+			"channel": "stable",
+			"changelog": "When using Action Button to factory reset (long press 20 seconds), all parameters (including parameter 120, 121, 128, 129, 130, 131, 132) will be reset to factory default settings.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6177502038",
+					"integrity": "sha256:e24aa361dd4d217550acbc1011db102ad42a3dab96d8b93b2c193f3cb919b4a7"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Add firmware upgrade for Aeotec Nano Dimmer ZW111-C EU version 2.04.

Firmware page:
https://aeotec.freshdesk.com/support/solutions/articles/6000198943-how-to-update-nano-dimmer-z-wave-firmware-
