### PR TITLE
Add Zooz ZSE11

### DIFF
--- a/firmwares/zooz/ZSE11.json
+++ b/firmwares/zooz/ZSE11.json
@@ -1,0 +1,25 @@
+{
+    "devices": [
+        {
+            "brand": "Zooz",
+            "model": "ZSE11",
+            "manufacturerId": "0x027a",
+            "productType": "0x0201",
+            "productId": "0x0006"
+        }
+    ],
+    "upgrades": [
+        {
+            "version": "1.11",
+            "changelog": "Fixed a lux reading bug where the sensor would report 0 in very bright settings.",
+            "url": "https://www.getzooz.com/firmware/ZSE11_FW_V1_11.otz",
+            "integrity": "sha256:fd0f4c9587597a971aee07ef190bb14c60a83319d0a0411944f3ff1fada995f2"
+        },
+        {
+            "version": "1.30",
+            "changelog": "Fixed an issue with S2 Authenticated security inclusion.",
+            "url": "https://www.getzooz.com/firmware/ZSE11_FW_V1_30.otz",
+            "integrity": "sha256:77f7bec56e5bb077a13a04bde9b92da91eb7ff2b124e7ee4eee3ffdafa0b0db3"
+        }
+    ]
+}


### PR DESCRIPTION
Firmware updates for the Zooz ZSE11 (Q Sensor) - The firmware 1.30 fixes an S2 issue that these devices had. In my case, it cleaned up some error messages in the ZWave JS UI logs.

Source: https://www.support.getzooz.com/kb/article/711-zse11-q-sensor-change-log/
Firmware from: https://www.support.getzooz.com/kb/article/1158-zooz-ota-firmware-files/

Thank you for maintaining this repo!