### PR TITLE
Update ZW100-A For Version Specific Update

### DIFF
--- a/firmwares/aeotec/ZW100-A.json
+++ b/firmwares/aeotec/ZW100-A.json
@@ -8,7 +8,7 @@
 			"productId": "0x0064"
 		}
 	],
-	"upgrades": [ //firmware V1.14 to V1.17
+	"upgrades": [
 		{
 			"$if": "firmwareVersion >= 1.14 && firmwareVersion < 1.17",
 			"version": "1.17",
@@ -19,6 +19,19 @@
 					"target": 0,
 					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6182582458",
 					"integrity": "sha256:301b047b71afcb7a10c746d5eee5fd2317e4807cc7eaa6acff2a62727408e522"
+				}
+			]
+		},
+		{
+			"$if": "firmwareVersion >= 1.09 && firmwareVersion < 1.13",
+			"version": "1.13",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Modified the humidity sensor checking. ",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6183346608",
+					"integrity": "sha256:6682e5b7db22471a908dc610b587c2b94a6e522919989b004bcbd091fa1d48c0"
 				}
 			]
 		}


### PR DESCRIPTION
Per https://aeotec.freshdesk.com/support/solutions/articles/6000036562-how-to-update-multisensor-6-z-wave-firmware-

V1.06 - V1.08 (Latest firmware is V1.08, updating above V1.08 will brick this sensor) V1.09 - V1.13 (Latest firmware is V1.13, updating above/below will have a higher chance of bricking this sensor) V1.14 - V1.17 (Latest firmware is V1.17, updating below V1.14 will brick this sensor)