### PR TITLE
Added 5 Shelly Qubino wave devices firmware update

### DIFF
--- a/firmwares/shelly/qnpl-001X12UK.json
+++ b/firmwares/shelly/qnpl-001X12UK.json
@@ -19,7 +19,7 @@
 			"region": "europe",
 			"files": [
 				{
-					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl",
+					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl",
 					"integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc"
 				}
 			]

--- a/firmwares/shelly/qnpl-001X12UK.json
+++ b/firmwares/shelly/qnpl-001X12UK.json
@@ -1,0 +1,31 @@
+{
+	"devices": [
+		{
+			"brand": "Shelly Qubino",
+			"model": "Wave Plug UK",
+			"manufacturerId": "0x0460",
+            "productType": "0x0002",
+			"productId": "0x0089",
+
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+        {
+			"version": "10.5",
+			"changelog": "- Fixed very low power reports\n- Improved voltage resolution\n- Meter report is now in mA (precision 3)\n- Added Association for Multilevel-Switch\n- other minor fixes and improvements",
+            "channel": "stable",
+            "region": "europe",
+            "files": [
+                {
+                    "target": 0,
+                    "integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc",
+                    "url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl"
+                }
+            ]	
+		}
+	]
+}

--- a/firmwares/shelly/qnpl-001X12UK.json
+++ b/firmwares/shelly/qnpl-001X12UK.json
@@ -4,9 +4,8 @@
 			"brand": "Shelly Qubino",
 			"model": "Wave Plug UK",
 			"manufacturerId": "0x0460",
-            "productType": "0x0002",
+			"productType": "0x0002",
 			"productId": "0x0089",
-
 			"firmwareVersion": {
 				"min": "0.0",
 				"max": "255.255"
@@ -14,18 +13,16 @@
 		}
 	],
 	"upgrades": [
-        {
+		{
 			"version": "10.5",
 			"changelog": "- Fixed very low power reports\n- Improved voltage resolution\n- Meter report is now in mA (precision 3)\n- Added Association for Multilevel-Switch\n- other minor fixes and improvements",
-            "channel": "stable",
-            "region": "europe",
-            "files": [
-                {
-                    "target": 0,
+			"region": "europe",
+			"files": [
+				{
 					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl",
-                    "integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc"
-                }
-            ]	
+					"integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc"
+				}
+			]
 		}
 	]
 }

--- a/firmwares/shelly/qnpl-001X12UK.json
+++ b/firmwares/shelly/qnpl-001X12UK.json
@@ -22,8 +22,8 @@
             "files": [
                 {
                     "target": 0,
-                    "integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc",
-                    "url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl"
+					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl",
+                    "integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc"
                 }
             ]	
 		}

--- a/firmwares/shelly/qnsh-001P10.json
+++ b/firmwares/shelly/qnsh-001P10.json
@@ -19,7 +19,7 @@
 			"region": "europe",
 			"files": [
 				{
-					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Shutter/EU/Wave_Shutter_800_EU_20231110_1035_QNSH-001P10EU_%5B12.17%5D_2144DF1C.gbl",
+					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_Shutter/EU/Wave_Shutter_800_EU_20231110_1035_QNSH-001P10EU_%5B12.17%5D_2144DF1C.gbl",
 					"integrity": "sha256:9c243f600c0a7d3a8c50a28c5af5378926279ee6ef664d7e1184a093253f4279"
 				}
 			]
@@ -30,7 +30,7 @@
 			"region": "usa",
 			"files": [
 				{
-					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/US/Wave_Shutter_800_US_20231115_0925_QNSH-001P10US_%5B12.17%5D_9DD2F96C.gbl",
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_Shutter/US/Wave_Shutter_800_US_20231115_0925_QNSH-001P10US_%5B12.17%5D_9DD2F96C.gbl",
 					"integrity": "sha256:066c3ea8d382d8078d59238eefb3f7255177f1200cd3b42f20424fc304d5ceef"
 				}
 			]
@@ -41,7 +41,7 @@
 			"region": "australia/new zealand",
 			"files": [
 				{
-					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/ANZ/Wave_Shutter_800_ANZ_20231115_0920_QNSH-001P10AU_%5B12.17%5D_9DD2F96C.gbl",
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_Shutter/ANZ/Wave_Shutter_800_ANZ_20231115_0920_QNSH-001P10AU_%5B12.17%5D_9DD2F96C.gbl",
 					"integrity": "sha256:583bf59dd49d5f50873970f5a0440487f94b8bca10379ea5bd1d185210b858e7"
 				}
 			]

--- a/firmwares/shelly/qnsh-001P10.json
+++ b/firmwares/shelly/qnsh-001P10.json
@@ -1,0 +1,58 @@
+{
+	"devices": [
+		{
+			"brand": "Shelly Qubino",
+			"model": "Wave Shutter",
+			"manufacturerId": "0x0460",
+            "productType": "0x0003",
+			"productId": "0x0082",
+
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+        {
+			"version": "12.17",
+			"changelog": "- Improved no line alarm detection\n- Filter on power spike reporting\n- two minor improvements",
+            "channel": "stable",
+            "region": "europe",
+            "files": [
+                {
+                    "target": 0,
+                    "integrity": "sha256:9c243f600c0a7d3a8c50a28c5af5378926279ee6ef664d7e1184a093253f4279",
+                    "url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Shutter/EU/Wave_Shutter_800_EU_20231110_1035_QNSH-001P10EU_%5B12.17%5D_2144DF1C.gbl"
+                }
+            ]	
+		},
+		{
+			"version": "12.17",
+			"changelog": "- Improved no line alarm detection\n- Filter on power spike reporting\n- two minor improvements",
+            "channel": "stable",
+            "region": "usa",
+            "files": [
+                {
+                    "target": 0,
+                    "integrity": "sha256:066c3ea8d382d8078d59238eefb3f7255177f1200cd3b42f20424fc304d5ceef",
+                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/US/Wave_Shutter_800_US_20231115_0925_QNSH-001P10US_%5B12.17%5D_9DD2F96C.gbl"
+                }
+            ]	
+		},
+		{
+			"version": "12.17",
+			"changelog": "- Improved no line alarm detection\n- Filter on power spike reporting\n- two minor improvements",
+            "channel": "stable",
+            "region": "australia/new zealand",
+            "files": [
+                {
+                    "target": 0,
+                    "integrity": "sha256:583bf59dd49d5f50873970f5a0440487f94b8bca10379ea5bd1d185210b858e7",
+                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/ANZ/Wave_Shutter_800_ANZ_20231115_0920_QNSH-001P10AU_%5B12.17%5D_9DD2F96C.gbl"
+                }
+            ]	
+		}
+		
+	]
+}

--- a/firmwares/shelly/qnsh-001P10.json
+++ b/firmwares/shelly/qnsh-001P10.json
@@ -22,8 +22,9 @@
             "files": [
                 {
                     "target": 0,
-                    "integrity": "sha256:9c243f600c0a7d3a8c50a28c5af5378926279ee6ef664d7e1184a093253f4279",
-                    "url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Shutter/EU/Wave_Shutter_800_EU_20231110_1035_QNSH-001P10EU_%5B12.17%5D_2144DF1C.gbl"
+					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Shutter/EU/Wave_Shutter_800_EU_20231110_1035_QNSH-001P10EU_%5B12.17%5D_2144DF1C.gbl",
+                    "integrity": "sha256:9c243f600c0a7d3a8c50a28c5af5378926279ee6ef664d7e1184a093253f4279"
+
                 }
             ]	
 		},
@@ -35,8 +36,9 @@
             "files": [
                 {
                     "target": 0,
-                    "integrity": "sha256:066c3ea8d382d8078d59238eefb3f7255177f1200cd3b42f20424fc304d5ceef",
-                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/US/Wave_Shutter_800_US_20231115_0925_QNSH-001P10US_%5B12.17%5D_9DD2F96C.gbl"
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/US/Wave_Shutter_800_US_20231115_0925_QNSH-001P10US_%5B12.17%5D_9DD2F96C.gbl",
+                    "integrity": "sha256:066c3ea8d382d8078d59238eefb3f7255177f1200cd3b42f20424fc304d5ceef"
+
                 }
             ]	
 		},
@@ -48,8 +50,8 @@
             "files": [
                 {
                     "target": 0,
-                    "integrity": "sha256:583bf59dd49d5f50873970f5a0440487f94b8bca10379ea5bd1d185210b858e7",
-                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/ANZ/Wave_Shutter_800_ANZ_20231115_0920_QNSH-001P10AU_%5B12.17%5D_9DD2F96C.gbl"
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/ANZ/Wave_Shutter_800_ANZ_20231115_0920_QNSH-001P10AU_%5B12.17%5D_9DD2F96C.gbl",
+                    "integrity": "sha256:583bf59dd49d5f50873970f5a0440487f94b8bca10379ea5bd1d185210b858e7"
                 }
             ]	
 		}

--- a/firmwares/shelly/qnsh-001P10.json
+++ b/firmwares/shelly/qnsh-001P10.json
@@ -4,9 +4,8 @@
 			"brand": "Shelly Qubino",
 			"model": "Wave Shutter",
 			"manufacturerId": "0x0460",
-            "productType": "0x0003",
+			"productType": "0x0003",
 			"productId": "0x0082",
-
 			"firmwareVersion": {
 				"min": "0.0",
 				"max": "255.255"
@@ -14,47 +13,38 @@
 		}
 	],
 	"upgrades": [
-        {
+		{
 			"version": "12.17",
 			"changelog": "- Improved no line alarm detection\n- Filter on power spike reporting\n- two minor improvements",
-            "channel": "stable",
-            "region": "europe",
-            "files": [
-                {
-                    "target": 0,
+			"region": "europe",
+			"files": [
+				{
 					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/main/Wave_Shutter/EU/Wave_Shutter_800_EU_20231110_1035_QNSH-001P10EU_%5B12.17%5D_2144DF1C.gbl",
-                    "integrity": "sha256:9c243f600c0a7d3a8c50a28c5af5378926279ee6ef664d7e1184a093253f4279"
-
-                }
-            ]	
+					"integrity": "sha256:9c243f600c0a7d3a8c50a28c5af5378926279ee6ef664d7e1184a093253f4279"
+				}
+			]
 		},
 		{
 			"version": "12.17",
 			"changelog": "- Improved no line alarm detection\n- Filter on power spike reporting\n- two minor improvements",
-            "channel": "stable",
-            "region": "usa",
-            "files": [
-                {
-                    "target": 0,
+			"region": "usa",
+			"files": [
+				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/US/Wave_Shutter_800_US_20231115_0925_QNSH-001P10US_%5B12.17%5D_9DD2F96C.gbl",
-                    "integrity": "sha256:066c3ea8d382d8078d59238eefb3f7255177f1200cd3b42f20424fc304d5ceef"
-
-                }
-            ]	
+					"integrity": "sha256:066c3ea8d382d8078d59238eefb3f7255177f1200cd3b42f20424fc304d5ceef"
+				}
+			]
 		},
 		{
 			"version": "12.17",
 			"changelog": "- Improved no line alarm detection\n- Filter on power spike reporting\n- two minor improvements",
-            "channel": "stable",
-            "region": "australia/new zealand",
-            "files": [
-                {
-                    "target": 0,
+			"region": "australia/new zealand",
+			"files": [
+				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_Shutter/ANZ/Wave_Shutter_800_ANZ_20231115_0920_QNSH-001P10AU_%5B12.17%5D_9DD2F96C.gbl",
-                    "integrity": "sha256:583bf59dd49d5f50873970f5a0440487f94b8bca10379ea5bd1d185210b858e7"
-                }
-            ]	
+					"integrity": "sha256:583bf59dd49d5f50873970f5a0440487f94b8bca10379ea5bd1d185210b858e7"
+				}
+			]
 		}
-		
 	]
 }

--- a/firmwares/shelly/qnsw-001P16.json
+++ b/firmwares/shelly/qnsw-001P16.json
@@ -4,9 +4,8 @@
 			"brand": "Shelly Qubino",
 			"model": "Wave 1 PM",
 			"manufacturerId": "0x0460",
-            "productType": "0x0002",
+			"productType": "0x0002",
 			"productId": "0x0084",
-
 			"firmwareVersion": {
 				"min": "0.0",
 				"max": "255.255"
@@ -14,19 +13,16 @@
 		}
 	],
 	"upgrades": [
-        {
+		{
 			"version": "11.5",
 			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off\n- Power measurement optimised for 'true power' measurement\n- Added filter for electrical disturbances to avoid unnecessary reporting\n- Circuit protection system (over current, overheat) detection improved\n- Improved power measurement system\n- Corrected configuration Command Class reports for non\n-existent parameters- Parameter 120 factory reset characteristics changed to size = 1 Byte\n- other minor fixes and improvements",
-            "channel": "stable",
-            "region": "europe",
-            "files": [
-                {
-                    "target": 0,
+			"region": "europe",
+			"files": [
+				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1PM/EU/QUBINO_Wave_1PM_800_EU_20231116_1316_QNSW-001P16EU_%5B11.05%5D_EB201890.gbl",
-                    "integrity": "sha256:870b3c8d525300619ed03554c2f51172bd3128d8df006c5106f91470746f4a99"
-
-                }
-            ]	
+					"integrity": "sha256:870b3c8d525300619ed03554c2f51172bd3128d8df006c5106f91470746f4a99"
+				}
+			]
 		}
 	]
 }

--- a/firmwares/shelly/qnsw-001P16.json
+++ b/firmwares/shelly/qnsw-001P16.json
@@ -1,0 +1,31 @@
+{
+	"devices": [
+		{
+			"brand": "Shelly Qubino",
+			"model": "Wave 1 PM",
+			"manufacturerId": "0x0460",
+            "productType": "0x0002",
+			"productId": "0x0084",
+
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+        {
+			"version": "11.5",
+			"changelog": "- Removed delay from input detection to output response\n- Power measurement optimised for 'true power' measurement\n- Added filter for electrical disturbances to avoid unnecessary reporting\n- Circuit protection system (over current, overheat) detection improved\n- Improved power measurement system\n- Corrected configuration Command Class reports for non\n-existent parameters- Parameter 120 factory reset characteristics changed to size = 1 Byte\n- other minor fixes and improvements",
+            "channel": "stable",
+            "region": "europe",
+            "files": [
+                {
+                    "target": 0,
+                    "integrity": "sha256:870b3c8d525300619ed03554c2f51172bd3128d8df006c5106f91470746f4a99",
+                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1PM/EU/QUBINO_Wave_1PM_800_EU_20231116_1316_QNSW-001P16EU_%5B11.05%5D_EB201890.gbl"
+                }
+            ]	
+		}
+	]
+}

--- a/firmwares/shelly/qnsw-001P16.json
+++ b/firmwares/shelly/qnsw-001P16.json
@@ -19,7 +19,7 @@
 			"region": "europe",
 			"files": [
 				{
-					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1PM/EU/QUBINO_Wave_1PM_800_EU_20231116_1316_QNSW-001P16EU_%5B11.05%5D_EB201890.gbl",
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_1PM/EU/QUBINO_Wave_1PM_800_EU_20231116_1316_QNSW-001P16EU_%5B11.05%5D_EB201890.gbl",
 					"integrity": "sha256:870b3c8d525300619ed03554c2f51172bd3128d8df006c5106f91470746f4a99"
 				}
 			]

--- a/firmwares/shelly/qnsw-001P16.json
+++ b/firmwares/shelly/qnsw-001P16.json
@@ -16,7 +16,7 @@
 	"upgrades": [
         {
 			"version": "11.5",
-			"changelog": "- Removed delay from input detection to output response\n- Power measurement optimised for 'true power' measurement\n- Added filter for electrical disturbances to avoid unnecessary reporting\n- Circuit protection system (over current, overheat) detection improved\n- Improved power measurement system\n- Corrected configuration Command Class reports for non\n-existent parameters- Parameter 120 factory reset characteristics changed to size = 1 Byte\n- other minor fixes and improvements",
+			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off\n- Power measurement optimised for 'true power' measurement\n- Added filter for electrical disturbances to avoid unnecessary reporting\n- Circuit protection system (over current, overheat) detection improved\n- Improved power measurement system\n- Corrected configuration Command Class reports for non\n-existent parameters- Parameter 120 factory reset characteristics changed to size = 1 Byte\n- other minor fixes and improvements",
             "channel": "stable",
             "region": "europe",
             "files": [

--- a/firmwares/shelly/qnsw-001P16.json
+++ b/firmwares/shelly/qnsw-001P16.json
@@ -22,8 +22,9 @@
             "files": [
                 {
                     "target": 0,
-                    "integrity": "sha256:870b3c8d525300619ed03554c2f51172bd3128d8df006c5106f91470746f4a99",
-                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1PM/EU/QUBINO_Wave_1PM_800_EU_20231116_1316_QNSW-001P16EU_%5B11.05%5D_EB201890.gbl"
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1PM/EU/QUBINO_Wave_1PM_800_EU_20231116_1316_QNSW-001P16EU_%5B11.05%5D_EB201890.gbl",
+                    "integrity": "sha256:870b3c8d525300619ed03554c2f51172bd3128d8df006c5106f91470746f4a99"
+
                 }
             ]	
 		}

--- a/firmwares/shelly/qnsw-001X16.json
+++ b/firmwares/shelly/qnsw-001X16.json
@@ -4,9 +4,8 @@
 			"brand": "Shelly Qubino",
 			"model": "Wave 1",
 			"manufacturerId": "0x0460",
-            "productType": "0x0002",
+			"productType": "0x0002",
 			"productId": "0x0083",
-
 			"firmwareVersion": {
 				"min": "0.0",
 				"max": "255.255"
@@ -14,33 +13,27 @@
 		}
 	],
 	"upgrades": [
-        {
+		{
 			"version": "11.3",
 			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off\n- Parameters 120, 201, 202, 203 fixed",
-            "channel": "stable",
-            "region": "europe",
-            "files": [
-                {
-                    "target": 0,
+			"region": "europe",
+			"files": [
+				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/EU/QUBINO_1Switch_800_EU_20231212_1546_QNSW-001X16EU_%5B11.03%5D_2144DF1C.gbl",
-                    "integrity": "sha256:8932688cf81c62c0ee3bc9d573c9055f25200d79baf369804c7695bd256bdcaf"
-
-                }
-            ]	
+					"integrity": "sha256:8932688cf81c62c0ee3bc9d573c9055f25200d79baf369804c7695bd256bdcaf"
+				}
+			]
 		},
 		{
 			"version": "11.3",
 			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off\n- Parameters 120, 201, 202, 203 fixed",
-            "channel": "stable",
-            "region": "australia/new zealand",
-            "files": [
-                {
-                    "target": 0,
+			"region": "australia/new zealand",
+			"files": [
+				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/ANZ/QUBINO_1Switch_800_ANZ_20240108_0921_QNSW-001X16AU_%5B11.03%5D_9DD2F96C.gbl",
-                    "integrity": "sha256:824ed1463259da1da197c369913b1303d16f0efa227373dea478e2aee47bfcd8"
-
-                }
-            ]	
+					"integrity": "sha256:824ed1463259da1da197c369913b1303d16f0efa227373dea478e2aee47bfcd8"
+				}
+			]
 		}
 	]
 }

--- a/firmwares/shelly/qnsw-001X16.json
+++ b/firmwares/shelly/qnsw-001X16.json
@@ -19,7 +19,7 @@
 			"region": "europe",
 			"files": [
 				{
-					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/EU/QUBINO_1Switch_800_EU_20231212_1546_QNSW-001X16EU_%5B11.03%5D_2144DF1C.gbl",
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_1/EU/QUBINO_1Switch_800_EU_20231212_1546_QNSW-001X16EU_%5B11.03%5D_2144DF1C.gbl",
 					"integrity": "sha256:8932688cf81c62c0ee3bc9d573c9055f25200d79baf369804c7695bd256bdcaf"
 				}
 			]
@@ -30,7 +30,7 @@
 			"region": "australia/new zealand",
 			"files": [
 				{
-					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/ANZ/QUBINO_1Switch_800_ANZ_20240108_0921_QNSW-001X16AU_%5B11.03%5D_9DD2F96C.gbl",
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_1/ANZ/QUBINO_1Switch_800_ANZ_20240108_0921_QNSW-001X16AU_%5B11.03%5D_9DD2F96C.gbl",
 					"integrity": "sha256:824ed1463259da1da197c369913b1303d16f0efa227373dea478e2aee47bfcd8"
 				}
 			]

--- a/firmwares/shelly/qnsw-001X16.json
+++ b/firmwares/shelly/qnsw-001X16.json
@@ -22,8 +22,9 @@
             "files": [
                 {
                     "target": 0,
-                    "integrity": "sha256:8932688cf81c62c0ee3bc9d573c9055f25200d79baf369804c7695bd256bdcaf",
-                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/EU/QUBINO_1Switch_800_EU_20231212_1546_QNSW-001X16EU_%5B11.03%5D_2144DF1C.gbl"
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/EU/QUBINO_1Switch_800_EU_20231212_1546_QNSW-001X16EU_%5B11.03%5D_2144DF1C.gbl",
+                    "integrity": "sha256:8932688cf81c62c0ee3bc9d573c9055f25200d79baf369804c7695bd256bdcaf"
+
                 }
             ]	
 		},
@@ -35,8 +36,9 @@
             "files": [
                 {
                     "target": 0,
-                    "integrity": "sha256:824ed1463259da1da197c369913b1303d16f0efa227373dea478e2aee47bfcd8",
-                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/ANZ/QUBINO_1Switch_800_ANZ_20240108_0921_QNSW-001X16AU_%5B11.03%5D_9DD2F96C.gbl"
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/ANZ/QUBINO_1Switch_800_ANZ_20240108_0921_QNSW-001X16AU_%5B11.03%5D_9DD2F96C.gbl",
+                    "integrity": "sha256:824ed1463259da1da197c369913b1303d16f0efa227373dea478e2aee47bfcd8"
+
                 }
             ]	
 		}

--- a/firmwares/shelly/qnsw-001X16.json
+++ b/firmwares/shelly/qnsw-001X16.json
@@ -1,0 +1,44 @@
+{
+	"devices": [
+		{
+			"brand": "Shelly Qubino",
+			"model": "Wave 1",
+			"manufacturerId": "0x0460",
+            "productType": "0x0002",
+			"productId": "0x0083",
+
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+        {
+			"version": "11.3",
+			"changelog": "- Removed delay from input detection to output response\n- Parameters 120, 201, 202, 203 fixed",
+            "channel": "stable",
+            "region": "europe",
+            "files": [
+                {
+                    "target": 0,
+                    "integrity": "sha256:8932688cf81c62c0ee3bc9d573c9055f25200d79baf369804c7695bd256bdcaf",
+                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/EU/QUBINO_1Switch_800_EU_20231212_1546_QNSW-001X16EU_%5B11.03%5D_2144DF1C.gbl"
+                }
+            ]	
+		},
+		{
+			"version": "11.3",
+			"changelog": "- Removed delay from input detection to output response\n- Parameters 120, 201, 202, 203 fixed",
+            "channel": "stable",
+            "region": "australia/new zealand",
+            "files": [
+                {
+                    "target": 0,
+                    "integrity": "sha256:824ed1463259da1da197c369913b1303d16f0efa227373dea478e2aee47bfcd8",
+                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_1/ANZ/QUBINO_1Switch_800_ANZ_20240108_0921_QNSW-001X16AU_%5B11.03%5D_9DD2F96C.gbl"
+                }
+            ]	
+		}
+	]
+}

--- a/firmwares/shelly/qnsw-001X16.json
+++ b/firmwares/shelly/qnsw-001X16.json
@@ -16,7 +16,7 @@
 	"upgrades": [
         {
 			"version": "11.3",
-			"changelog": "- Removed delay from input detection to output response\n- Parameters 120, 201, 202, 203 fixed",
+			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off\n- Parameters 120, 201, 202, 203 fixed",
             "channel": "stable",
             "region": "europe",
             "files": [
@@ -30,7 +30,7 @@
 		},
 		{
 			"version": "11.3",
-			"changelog": "- Removed delay from input detection to output response\n- Parameters 120, 201, 202, 203 fixed",
+			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off\n- Parameters 120, 201, 202, 203 fixed",
             "channel": "stable",
             "region": "australia/new zealand",
             "files": [

--- a/firmwares/shelly/qnsw-002P16.json
+++ b/firmwares/shelly/qnsw-002P16.json
@@ -22,8 +22,8 @@
             "files": [
                 {
                     "target": 0,
-                    "integrity": "sha256:1cf4865c47749441f8e165c4aa1c61f19a622235d2b072a9c5b89aaa4114eeb3",
-                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/EU/QUBINO_Wave2PM_800_EU_20231213_1356_QNSW-002P16EU_%5B10.30%5D_EB201890.gbl"
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/EU/QUBINO_Wave2PM_800_EU_20231213_1356_QNSW-002P16EU_%5B10.30%5D_EB201890.gbl",
+                    "integrity": "sha256:1cf4865c47749441f8e165c4aa1c61f19a622235d2b072a9c5b89aaa4114eeb3"
                 }
             ]	
 		},
@@ -35,8 +35,8 @@
             "files": [
                 {
                     "target": 0,
-                    "integrity": "sha256:d8ada46967e45358a192f4557b02ec95f99678c6051eaad560b15bdf742b00f4",
-                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/ANZ/QUBINO_Wave2PM_800_ANZ_20240108_1015_QNSW-002P16AU_%5B10.30%5D_0FE4B35C.gbl"
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/ANZ/QUBINO_Wave2PM_800_ANZ_20240108_1015_QNSW-002P16AU_%5B10.30%5D_0FE4B35C.gbl",
+                    "integrity": "sha256:d8ada46967e45358a192f4557b02ec95f99678c6051eaad560b15bdf742b00f4"
                 }
             ]	
 		}

--- a/firmwares/shelly/qnsw-002P16.json
+++ b/firmwares/shelly/qnsw-002P16.json
@@ -1,0 +1,44 @@
+{
+	"devices": [
+		{
+			"brand": "Shelly Qubino",
+			"model": "Wave 2PM",
+			"manufacturerId": "0x0460",
+            "productType": "0x0002",
+			"productId": "0x0081",
+
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+        {
+			"version": "10.30",
+			"changelog": "- Removed delay from input detection to output response",
+            "channel": "stable",
+            "region": "europe",
+            "files": [
+                {
+                    "target": 0,
+                    "integrity": "sha256:1cf4865c47749441f8e165c4aa1c61f19a622235d2b072a9c5b89aaa4114eeb3",
+                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/EU/QUBINO_Wave2PM_800_EU_20231213_1356_QNSW-002P16EU_%5B10.30%5D_EB201890.gbl"
+                }
+            ]	
+		},
+		{
+			"version": "10.30",
+			"changelog": "- Removed delay from input detection to output response",
+            "channel": "stable",
+            "region": "australia/new zealand",
+            "files": [
+                {
+                    "target": 0,
+                    "integrity": "sha256:d8ada46967e45358a192f4557b02ec95f99678c6051eaad560b15bdf742b00f4",
+                    "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/ANZ/QUBINO_Wave2PM_800_ANZ_20240108_1015_QNSW-002P16AU_%5B10.30%5D_0FE4B35C.gbl"
+                }
+            ]	
+		}
+	]
+}

--- a/firmwares/shelly/qnsw-002P16.json
+++ b/firmwares/shelly/qnsw-002P16.json
@@ -19,7 +19,7 @@
 			"region": "europe",
 			"files": [
 				{
-					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/EU/QUBINO_Wave2PM_800_EU_20231213_1356_QNSW-002P16EU_%5B10.30%5D_EB201890.gbl",
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_2PM/EU/QUBINO_Wave2PM_800_EU_20231213_1356_QNSW-002P16EU_%5B10.30%5D_EB201890.gbl",
 					"integrity": "sha256:1cf4865c47749441f8e165c4aa1c61f19a622235d2b072a9c5b89aaa4114eeb3"
 				}
 			]
@@ -30,7 +30,7 @@
 			"region": "australia/new zealand",
 			"files": [
 				{
-					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/ANZ/QUBINO_Wave2PM_800_ANZ_20240108_1015_QNSW-002P16AU_%5B10.30%5D_0FE4B35C.gbl",
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_2PM/ANZ/QUBINO_Wave2PM_800_ANZ_20240108_1015_QNSW-002P16AU_%5B10.30%5D_0FE4B35C.gbl",
 					"integrity": "sha256:d8ada46967e45358a192f4557b02ec95f99678c6051eaad560b15bdf742b00f4"
 				}
 			]

--- a/firmwares/shelly/qnsw-002P16.json
+++ b/firmwares/shelly/qnsw-002P16.json
@@ -16,7 +16,7 @@
 	"upgrades": [
         {
 			"version": "10.30",
-			"changelog": "- Removed delay from input detection to output response",
+			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off",
             "channel": "stable",
             "region": "europe",
             "files": [
@@ -29,7 +29,7 @@
 		},
 		{
 			"version": "10.30",
-			"changelog": "- Removed delay from input detection to output response",
+			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off",
             "channel": "stable",
             "region": "australia/new zealand",
             "files": [

--- a/firmwares/shelly/qnsw-002P16.json
+++ b/firmwares/shelly/qnsw-002P16.json
@@ -4,9 +4,8 @@
 			"brand": "Shelly Qubino",
 			"model": "Wave 2PM",
 			"manufacturerId": "0x0460",
-            "productType": "0x0002",
+			"productType": "0x0002",
 			"productId": "0x0081",
-
 			"firmwareVersion": {
 				"min": "0.0",
 				"max": "255.255"
@@ -14,31 +13,27 @@
 		}
 	],
 	"upgrades": [
-        {
+		{
 			"version": "10.30",
 			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off",
-            "channel": "stable",
-            "region": "europe",
-            "files": [
-                {
-                    "target": 0,
+			"region": "europe",
+			"files": [
+				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/EU/QUBINO_Wave2PM_800_EU_20231213_1356_QNSW-002P16EU_%5B10.30%5D_EB201890.gbl",
-                    "integrity": "sha256:1cf4865c47749441f8e165c4aa1c61f19a622235d2b072a9c5b89aaa4114eeb3"
-                }
-            ]	
+					"integrity": "sha256:1cf4865c47749441f8e165c4aa1c61f19a622235d2b072a9c5b89aaa4114eeb3"
+				}
+			]
 		},
 		{
 			"version": "10.30",
 			"changelog": "- Removed delay from input detection to output response\n- Fix Binary Switch report after auto off",
-            "channel": "stable",
-            "region": "australia/new zealand",
-            "files": [
-                {
-                    "target": 0,
+			"region": "australia/new zealand",
+			"files": [
+				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_2PM/ANZ/QUBINO_Wave2PM_800_ANZ_20240108_1015_QNSW-002P16AU_%5B10.30%5D_0FE4B35C.gbl",
-                    "integrity": "sha256:d8ada46967e45358a192f4557b02ec95f99678c6051eaad560b15bdf742b00f4"
-                }
-            ]	
+					"integrity": "sha256:d8ada46967e45358a192f4557b02ec95f99678c6051eaad560b15bdf742b00f4"
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
FW for devices Wave 1, Wave 1PM, Wave 2PM, Wave Shutter, Wave Plug UK

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->