### PR TITLE
Add EU version for Zooz ZEN53, ZAC38

### DIFF
--- a/firmwares/zooz/ZAC38.json
+++ b/firmwares/zooz/ZAC38.json
@@ -15,9 +15,17 @@
 	"upgrades": [
 		{
 			"version": "1.30.0",
+			"region": "usa",
 			"changelog": "* Includes firmware versions: 1.0, 1.20, 1.30\n* Addressed issues with the range extender occasionally showing offline or becoming unresponsive on select platforms.",
 			"url": "https://www.getzooz.com/firmware/ZAC38_V01R30.gbl",
 			"integrity": "sha256:942d61465d17f7e4d70a2824b89ee2c92aea709c6e07ded17ed682a9cee8c805"
+		},
+		{
+			"version": "1.30.0",
+			"region": "europe",
+			"changelog": "* Includes firmware versions: 1.0, 1.20, 1.30\n* Addressed issues with the range extender occasionally showing offline or becoming unresponsive on select platforms.",
+			"url": "https://www.getzooz.com/firmware/ZAC38_V01R30_EU.gbl",
+			"integrity": "sha256:b2b33bec395904ca79b4f4e1ac4f62cd2ffb944d736096a53709ca78810419a7"
 		}
 	]
 }

--- a/firmwares/zooz/ZEN53.json
+++ b/firmwares/zooz/ZEN53.json
@@ -15,9 +15,17 @@
 	"upgrades": [
 		{
 			"version": "1.40.0",
+			"region": "usa",
 			"changelog": "Includes firmware versions: 1.0, 1.20, 1.30, 1.40.\n*  Added Parameter 19: Timer for the motor open-up operation.\n*  Added Parameter 20: Timer for the motor close-down operation.",
 			"url": "https://www.getzooz.com/firmware/ZEN53_V01R40.gbl",
 			"integrity": "sha256:1d81b6e8ed045f308f4c8cf50f14452c4896d2b846558c49e4577d1443a82ae6"
+		},
+		{
+			"version": "1.40.0",
+			"region": "europe",
+			"changelog": "Includes firmware versions: 1.0, 1.20, 1.30, 1.40.\n*  Added Parameter 19: Timer for the motor open-up operation.\n*  Added Parameter 20: Timer for the motor close-down operation.",
+			"url": "https://www.getzooz.com/firmware/ZEN53_V01R40_EU.gbl",
+			"integrity": "sha256:35c59d94497f2b20bcd61b8983ca5038fb352a8ada69710d82efcf4864657fa2"
 		}
 	]
 }


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->