### PR TITLE
Update Zooz ZEN74 min version

### DIFF
--- a/firmwares/zooz/ZEN74.json
+++ b/firmwares/zooz/ZEN74.json
@@ -7,7 +7,7 @@
 			"productType": "0x7000",
 			"productId": "0xa004",
 			"firmwareVersion": {
-				"min": "1.0",
+				"min": "10.0",
 				"max": "10.255"
 			}
 		}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->