### PR TITLE
Add Aeotec ZW175-C EU firmware version 1.3

### DIFF
--- a/firmwares/aeotec/ZW175-C.json
+++ b/firmwares/aeotec/ZW175-C.json
@@ -1,0 +1,26 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW175-C",
+			"manufacturerId": "0x0371",
+			"productType": "0x0003", // EU
+			"productId": "0x00af"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.3",
+			"channel": "stable",
+			//"region": "europe",
+			"changelog": "Bug Fixes:\n* Fixes threshold reporting to allow a change in threshold to initiate multiple reports if there is watt change that is above 0W",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6191002461",
+					"integrity": "sha256:e948ea85e536a98cc0ad824fe8c92db9b2de8fe8058a9c44a1fd1a7af6e8c98c"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->

This adds firmware 1.3 for the **EU version** of the **Aeotec Smart Switch 7** which was [recently made available](https://aeotec.freshdesk.com/support/solutions/articles/6000270359-update-smart-switch-7-eu-v1-03-zw175-c-). It fixes a rather annoying bug where the change threshold settings don't do anything when the initial value is above 0 (at least for the Watts sensor, though I'm not entirely sure other sensors were not affected as well).

@Aeotec-ccheng Could you please review this PR?