### PR TITLE
Update Aeotec ZWA024 firmware from 1.6.6 to 1.6.7

### DIFF
--- a/firmwares/aeotec/ZWA024-A.json
+++ b/firmwares/aeotec/ZWA024-A.json
@@ -10,16 +10,16 @@
 	],
 	"upgrades": [
 		{
-			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.6",
-			"version": "1.6",
+			//"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.6.7",
+			"version": "1.6.7",
 			"channel": "stable",
 			//"region": "usa",
-			"changelog": "Bug Fixes:\n* Threshold parameters\n* UV sensor calculations\n* Sensor freeze\n* Temperature value calculation on USB",
+			"changelog": "Resolves issue where motion timeout happens earlier than expected based on retrigger (parameter 2) when on USB power.",
 			"files": [
 				{
 					"target": 0,
-					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6179822542",
-					"integrity": "sha256:8dbe7c921097a3d753cf44bccbbf4b1a15a76d182981e3158949debbbb327a51"
+					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6192841343",
+					"integrity": "sha256:edb536feff0e8dbf83ea76f2c7a3f19537a28539a7b30497f68920f721bc5019"
 				}
 			]
 		}

--- a/firmwares/aeotec/ZWA024-B.json
+++ b/firmwares/aeotec/ZWA024-B.json
@@ -10,16 +10,16 @@
 	],
 	"upgrades": [
 		{
-			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.6",
-			"version": "1.6",
+			//"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.6.7",
+			"version": "1.6.7",
 			"channel": "stable",
 			//"region": "australia/new zealand",
-			"changelog": "Bug Fixes:\n* Threshold parameters\n* UV sensor calculations\n* Sensor freeze\n* Temperature value calculation on USB",
+			"changelog": "Resolves issue where motion timeout happens earlier than expected based on retrigger (parameter 2) when on USB power.",
 			"files": [
 				{
 					"target": 0,
-					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6188454160",
-					"integrity": "sha256:cbf548674b5523bd882dbaee28b407bd3b7662832bf30de87ffb1733ed0166aa"
+					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6193190122",
+					"integrity": "sha256:05ce149ddfc8143a9639a12b3e7a3a0033f588a84c40dabe1a8085c6559e1c03"
 				}
 			]
 		}

--- a/firmwares/aeotec/ZWA024-C.json
+++ b/firmwares/aeotec/ZWA024-C.json
@@ -10,16 +10,16 @@
 	],
 	"upgrades": [
 		{
-			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.6",
-			"version": "1.6",
+			//"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.6.7",
+			"version": "1.6.7",
 			"channel": "stable",
 			//"region": "europe",
-			"changelog": "Bug Fixes:\n* Threshold parameters\n* UV sensor calculations\n* Sensor freeze\n* Temperature value calculation on USB",
+			"changelog": "Resolves issue where motion timeout happens earlier than expected based on retrigger (parameter 2) when on USB power.",
 			"files": [
 				{
 					"target": 0,
-					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6179822541",
-					"integrity": "sha256:7e53c458e33758a3a50afbef2d474b60e7272ca4f3aeffc2dfe5f9f7f56d400c"
+					"url": "https://aeotec.freshdesk.com/helpdesk/attachments/6192841342",
+					"integrity": "sha256:511e214600fa99c426a39f7ce886a6b111793dfe6747d5174939f5a4a7d0b318"
 				}
 			]
 		}


### PR DESCRIPTION
Update Aeotec MultiSensor 7 (ZWA024) firmware from 1.6.6 to 1.6.7. 

Note that the previous firmware did not contain version 1.6, but 1.6.6.

I've removed 1.6.6. Or should I better keep both versions in the `upgrades` list?