### PR TITLE
Add Country and Version for Zooz ZEN77-800-LR and ZEN72-800-LR

### DIFF
--- a/firmwares/zooz/ZEN72-800-LR.json
+++ b/firmwares/zooz/ZEN72-800-LR.json
@@ -13,8 +13,17 @@
 		}
 	],
 	"upgrades": [
+		
+		{
+			"version": "3.40.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 3.0, 3.10, 3.20, 3.30, 3.40. \n* Fixed the Range Test Tool feature.\n* Added a new parameter 33: Convert the dimmer to a switch.",
+			"url": "https://www.getzooz.com/firmware/ZEN72_V03R40.gbl",
+			"integrity": "sha256:b1c2c48d449749994d19610839ecc03987434baadba078aaab3df028e2965196"
+		},
 		{
 			"version": "3.30.0",
+			"region": "usa",
 			"changelog": "Includes firmware versions: 3.0, 3.10, 3.20, 3.30.\n* Improved Direct Association Group 3 for the multilevel set functionality.",
 			"url": "https://www.getzooz.com/firmware/ZEN72_V03R30.gbl",
 			"integrity": "sha256:67610e8ba6fff5089b9d1bb42b7ca7515df6079909caf4cdd21889746c318feb"

--- a/firmwares/zooz/ZEN72-800-LR.json
+++ b/firmwares/zooz/ZEN72-800-LR.json
@@ -13,7 +13,6 @@
 		}
 	],
 	"upgrades": [
-		
 		{
 			"version": "3.40.0",
 			"region": "usa",

--- a/firmwares/zooz/ZEN77-800-LR.json
+++ b/firmwares/zooz/ZEN77-800-LR.json
@@ -14,7 +14,15 @@
 	],
 	"upgrades": [
 		{
+			"version": "4.50.1",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 4.10, 4.20, 4.30, 4.40, 4.50.\n* Fixed the Range Test Tool feature.\n* Added a new parameter 33: Convert the dimmer to a switch.",
+			"url": "https://www.getzooz.com/firmware/ZEN77_V04R50.gbl",
+			"integrity": "sha256:ff6ea11f5718ebe6fb8bac1a1183ebe15d70f059dac9a44b60a0b67f36ae8bb9"
+		},
+		{
 			"version": "4.30.0",
+			"region": "usa",
 			"changelog": "Includes firmware versions: 4.10, 4.20, 4.30.\n* Improved Direct Association Group 3 for the multilevel set functionality.",
 			"url": "https://www.getzooz.com/firmware/ZEN77_V04R30.gbl",
 			"integrity": "sha256:56547dda70a62ca6f47d8d766ef9646db8b42189efe60d0239eb3c73b59fac8d"


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->