### PR TITLE
Update: ZEN54, ZEN51, ZEN52, ZEN76-V02, ZEN76-800, ZEN71-V02, ZEN71-800

### DIFF
--- a/firmwares/zooz/ZEN51.json
+++ b/firmwares/zooz/ZEN51.json
@@ -14,6 +14,13 @@
 	],
 	"upgrades": [
 		{
+			"version": "1.80.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 1.0, 1.10, 1.30, 1.40, 1.50, 1.60, 1.70, 1.80.\n* Fixed a bug: The parent (root) device will update its state correctly now on select platforms.\n* Fixed a bug: Solved an issue with the external switch not triggering the load in some edge cases.\n* Fixed an issue with the connected load flickering on occasion.\n* Added parameter 13: Separate the input from the output.",
+			"url": "https://www.getzooz.com/firmware/ZEN51_V01R80.gbl",
+			"integrity": "sha256:dfc21f50841189a43cee4ac2d4ccbccc456f66d4ec97a56d0f11820cd6e8ee93"
+		},
+		{
 			"version": "1.70.0",
 			"region": "usa",
 			"changelog": "Includes firmware versions: 1.0, 1.10, 1.30, 1.40, 1.50, 1.60, 1.70.\n*  Removed the delay when controlling the ZEN51 from the external mechanical switch when parameter 12 is set to value 0.",

--- a/firmwares/zooz/ZEN52.json
+++ b/firmwares/zooz/ZEN52.json
@@ -14,6 +14,13 @@
 	],
 	"upgrades": [
 		{
+			"version": "1.80.0",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 1.10, 1.20, 1.30, 1.40, 1.50, 1.60, 1.70, 1.80.\n* Fixed a bug: The parent (root) device will update its state correctly now on select platforms.\n* Fixed a bug: Solved an issue with the external switch not triggering the load in some edge cases.\n* Fixed an issue with the connected load flickering on occasion.\n* Added parameter 28: Separate the inputs from the outputs.\n* Added parameter 29: DC Motor Mode.",
+			"url": "https://www.getzooz.com/firmware/ZEN52_V01R80.gbl",
+			"integrity": "sha256:e7c0310b063a3f8144efa5070ec3d94948bd6d7145fd82141d70c6cf14453f23"
+		},
+		{
 			"version": "1.70.0",
 			"region": "usa",
 			"changelog": "* Includes firmware versions: 1.10, 1.20, 1.30, 1.40, 1.50, 1.60, 1.70\n* Removed the delay when controlling the ZEN52 from the external mechanical switch when parameter 27 is set to value 0.\n* Fixed bug: Both external switches can be triggered at the same time now.",

--- a/firmwares/zooz/ZEN54.json
+++ b/firmwares/zooz/ZEN54.json
@@ -14,8 +14,16 @@
 	],
 	"upgrades": [
 		{
+			"version": "1.40.1",
+			"changelog": "Includes firmware versions: 1.0, 1.20, 1.30, 1.40.\n* Added advanced parameter 19: Custom brightness level for ON command.",
+			"region": "usa",
+			"url": "https://www.getzooz.com/firmware/ZEN54_V01R40.gbl",
+			"integrity": "sha256:360078bb91f98dab540bb83ef699ce5780feadada9e54372d23e57427d0d2c51"
+		},
+		{
 			"version": "1.30.0",
-			"changelog": "* Added advanced parameters 15 and 16 for the Physical Ramp Rates.\n* Added advanced parameters 17 and 18 for the Z-Wave Ramp Rates.",
+			"changelog": "Includes firmware versions: 1.0, 1.20, 1.30.\n* Added advanced parameters 15 and 16 for the Physical Ramp Rates.\n* Added advanced parameters 17 and 18 for the Z-Wave Ramp Rates.",
+			"region": "usa",
 			"url": "https://www.getzooz.com/firmware/ZEN54_V01R30.gbl",
 			"integrity": "sha256:cfcb2f9bfbd4db73c3f8f75c6bc01ed6dee7c618797ecde79e95d2bfa5b72d44"
 		}

--- a/firmwares/zooz/ZEN71-800-LR.json
+++ b/firmwares/zooz/ZEN71-800-LR.json
@@ -14,7 +14,15 @@
 	],
 	"upgrades": [
 		{
+			"version": "3.40.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 3.10, 3.20, 3.30, 3.40.\n* Fixed the Range Test Tool feature.",
+			"url": "https://www.getzooz.com/firmware/ZEN71_V03R40.gbl",
+			"integrity": "sha256:e35ea14e79ebfc292fbe82805fb9a8cece38e3fc4af8e694fa7d2a7b29b9aa87"
+		},
+		{
 			"version": "3.30.0",
+			"region": "usa",
 			"changelog": "Includes firmware versions: 3.10, 3.20, 3.30.\n* Improved Direct Association Group 2 for the basic set on/off functionality.",
 			"url": "https://www.getzooz.com/firmware/ZEN71_V03R30.gbl",
 			"integrity": "sha256:792a18c55f3e123391807526a8ab1d0681f39f1295f98120a7686140d0e77eaf"

--- a/firmwares/zooz/ZEN71-V02.json
+++ b/firmwares/zooz/ZEN71-V02.json
@@ -14,7 +14,15 @@
 	],
 	"upgrades": [
 		{
+			"version": "2.30.1",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 2.0, 2.10, 2.20, 2.30.\n* Improved Direct Association Group 2 for the basic set on/off functionality.",
+			"url": "https://www.getzooz.com/firmware/ZEN71_V02R30.gbl",
+			"integrity": "sha256:d316d42f1ca04f05bdae7edef2c42f85ffa113f0f5db8c7e72fe40b1d89224ac"
+		},
+		{
 			"version": "2.20.1",
+			"region": "usa",
 			"changelog": "Includes firmware versions: 2.0, 2.10, 2.20.\n* Fixed central scene bug for control of its own load in smart bulb mode.\n* Added parameter 7 to choose Direct Association reports sent to devices associated with the Z-Wave.\n* Added parameter 18 to enable scene control from the momentary switch in a 3-way.\n* Added parameter 19 to disable LED blinking when a setting is changed.\n* Changed the manual operation for disabling the relay (smart bulb mode): Hold the UPPER paddle for 10 seconds until the LED indicator starts blinking, then within 2 seconds, tap the upper paddle 5 times quickly to change this mode. The LED indicator will stay solid green for 3 seconds to confirm the change.\n* Improved the factory reset procedure: The switch will not lock up if the factory reset is not successful in certain scenarios.",
 			"url": "https://www.getzooz.com/firmware/ZEN71_V02R20.gbl",
 			"integrity": "sha256:f0c8e80d27032b9a61d230759a774f34c1d802137fbd7d9b0e9d1bac31c04c13"

--- a/firmwares/zooz/ZEN76-800.json
+++ b/firmwares/zooz/ZEN76-800.json
@@ -14,7 +14,15 @@
 	],
 	"upgrades": [
 		{
+			"version": "3.40.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 3.10, 3.20, 3.30, 3.40.\n* Fixed the Range Test Tool feature.",
+			"url": "https://www.getzooz.com/firmware/ZEN76_V03R40.gbl",
+			"integrity": "sha256:b7f0deeab952b164c629cdd2f416e5bd1fd452991adb8a9cc9da788f2fb7af5a"
+		},
+		{
 			"version": "3.30.0",
+			"region": "usa",
 			"changelog": "Includes firmware versions: 3.10, 3.20, 3.30.\n* Improved Direct Association Group 2 for the basic set on/off functionality.",
 			"url": "https://www.getzooz.com/firmware/ZEN76_V03R30.gbl",
 			"integrity": "sha256:2da835e3246c83036d13e47f8660f5a1b25570bb8c15506b5913c2c0557c4018"

--- a/firmwares/zooz/ZEN76-V02.json
+++ b/firmwares/zooz/ZEN76-V02.json
@@ -14,7 +14,15 @@
 	],
 	"upgrades": [
 		{
+			"version": "2.30.1",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 2.0, 2.10, 2.20, 2.30.\n* Improved Direct Association Group 2 for the basic set on/off functionality.",
+			"url": "https://www.getzooz.com/firmware/ZEN76_V02R30.gbl",
+			"integrity": "sha256:c2ddc053aed930c3aa8c47b71b506c8f7b806cff5d7c636b6df1f16687498d33"
+		},
+		{
 			"version": "2.20.1",
+			"region": "usa",
 			"changelog": "Includes firmware versions: 2.0, 2.10, 2.20.\n* Fixed central scene bug for control of its own load in smart bulb mode.\n* Added parameter 18 to disable LED blinking when a setting is changed. See all settings here.\n* Changed the manual operation for disabling the relay (smart bulb mode).\n* Improved the factory reset procedure: The switch will not lock up if the factory reset is not successful in certain scenarios.",
 			"url": " https://www.getzooz.com/firmware/ZEN76_V02R20.gbl",
 			"integrity": "sha256:d58c3bcdb7bcb1a1e51314c155a205a095e81a9cc0e0bdda0db8e5dcd6bb82c0"


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->