### PR TITLE
Zooz ZEN76 800LR: add version 3.50

### DIFF
--- a/firmwares/zooz/ZEN76-V03-800-LR.json
+++ b/firmwares/zooz/ZEN76-V03-800-LR.json
@@ -14,6 +14,13 @@
 	],
 	"upgrades": [
 		{
+			"version": "3.50.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 3.10, 3.20, 3.30, 3.40, 3.50.\n* Updated parameter names and short descriptions in the Configuration Command Classe.",
+			"url": "https://www.getzooz.com/firmware/ZEN76_V03R50.gbl",
+			"integrity": "sha256:5567b105b530f146e2642af050468398ee6fdbc2bacf61d6ebba7b760a0a3647"
+		},
+		{
 			"version": "3.40.0",
 			"region": "usa",
 			"changelog": "Includes firmware versions: 3.10, 3.20, 3.30, 3.40.\n* Fixed the Range Test Tool feature.",

--- a/firmwares/zooz/ZEN76-V03-800-LR.json
+++ b/firmwares/zooz/ZEN76-V03-800-LR.json
@@ -16,7 +16,7 @@
 		{
 			"version": "3.50.0",
 			"region": "usa",
-			"changelog": "Includes firmware versions: 3.10, 3.20, 3.30, 3.40, 3.50.\n* Updated parameter names and short descriptions in the Configuration Command Classe.",
+			"changelog": "Includes firmware versions: 3.10, 3.20, 3.30, 3.40, 3.50.\n* Updated parameter names and short descriptions in the Configuration Command Class.",
 			"url": "https://www.getzooz.com/firmware/ZEN76_V03R50.gbl",
 			"integrity": "sha256:5567b105b530f146e2642af050468398ee6fdbc2bacf61d6ebba7b760a0a3647"
 		},


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->