### PR TITLE
Add productType 0x0104 for Zooz ZEN52

### DIFF
--- a/firmwares/zooz/ZEN52.json
+++ b/firmwares/zooz/ZEN52.json
@@ -5,6 +5,19 @@
 			"model": "ZEN52",
 			"manufacturerId": "0x027a",
 			"productType": "0x0904",
+			//Z-Wave Certification Date: 2/2/2023
+			"productId": "0x0202",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "1.255"
+			}
+		},
+		{
+			"brand": "Zooz",
+			"model": "ZEN52",
+			"manufacturerId": "0x027a",
+			"productType": "0x0104",
+			//Z-Wave Certification Date: 4/4/2022
 			"productId": "0x0202",
 			"firmwareVersion": {
 				"min": "0.0",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->