### PR TITLE
Update: ZEN51 firmware 1.90 US and EU

### DIFF
--- a/firmwares/zooz/ZEN51.json
+++ b/firmwares/zooz/ZEN51.json
@@ -27,6 +27,13 @@
 	],
 	"upgrades": [
 		{
+			"version": "1.90.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 1.0, 1.10, 1.30, 1.40, 1.50, 1.60, 1.70, 1.80, 1.90.\n* This firmware version is compatible with hardware version 1.10 or 1.30 and higher. You can check your hardware version on the back of the ZEN51 module.\n* Updated parameter names and short descriptions in the Configuration Command Class for improved clarity and consistency.\n* Fixed an issue with LED behavior when the ZEN51 is included in a Z-Wave network — the LED now follows Parameter 1 settings as expected.\n* Resolved a mechanical switch issue that occurred when firmware version 1.80 was flashed to hardware version 1.10. The mechanical switch now functions properly on both hardware versions.\n* Optimized Z-Wave reporting behavior: when Basic Set or Binary Set commands are sent from the Z-Wave controller (Lifeline), the device will no longer send redundant report or notification commands back to the controller.",
+			"url": "https://www.getzooz.com/firmware/ZEN51_V01R90.gbl",
+			"integrity": "sha256:490cff997066b20ea8cc7192c61cbe3adf9b321b751ce6fdeab8e7df900fe0d7"
+		},
+		{
 			"version": "1.80.0",
 			"region": "usa",
 			"changelog": "Includes firmware versions: 1.0, 1.10, 1.30, 1.40, 1.50, 1.60, 1.70, 1.80.\n* Fixed a bug: The parent (root) device will update its state correctly now on select platforms.\n* Fixed a bug: Solved an issue with the external switch not triggering the load in some edge cases.\n* Fixed an issue with the connected load flickering on occasion.\n* Added parameter 13: Separate the input from the output.",
@@ -39,6 +46,13 @@
 			"changelog": "Includes firmware versions: 1.0, 1.10, 1.30, 1.40, 1.50, 1.60, 1.70.\n*  Removed the delay when controlling the ZEN51 from the external mechanical switch when parameter 12 is set to value 0.",
 			"url": "https://www.getzooz.com/firmware/ZEN51_V01R70.gbl",
 			"integrity": "sha256:78f5ee765b275e9471bef2528e7a0468bfc2a95bc25dc1bd687bbb62874999ae"
+		},
+		{
+			"version": "1.90.0",
+			"region": "europe",
+			"changelog": "Includes firmware versions: 1.0, 1.10, 1.30, 1.40, 1.50, 1.60, 1.70, 1.80, 1.90.\n* This firmware version is compatible with hardware version 1.10 or 1.30 and higher. You can check your hardware version on the back of the ZEN51 module.\n* Updated parameter names and short descriptions in the Configuration Command Class for improved clarity and consistency.\n* Fixed an issue with LED behavior when the ZEN51 is included in a Z-Wave network — the LED now follows Parameter 1 settings as expected.\n* Resolved a mechanical switch issue that occurred when firmware version 1.80 was flashed to hardware version 1.10. The mechanical switch now functions properly on both hardware versions.\n* Optimized Z-Wave reporting behavior: when Basic Set or Binary Set commands are sent from the Z-Wave controller (Lifeline), the device will no longer send redundant report or notification commands back to the controller.",
+			"url": "https://www.getzooz.com/firmware/ZEN51_V01R90_EU.gbl",
+			"integrity": "sha256:8316ba265ec00abfcc7612930fd02ec062e1f3b6a2464035b297d3bbbfba643c"
 		},
 		{
 			"version": "1.70.0",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->