### PR TITLE
Add Zooz ZEN32, firmware 10.50.2 (USA region)

### DIFF
--- a/firmwares/zooz/ZEN32.json
+++ b/firmwares/zooz/ZEN32.json
@@ -14,8 +14,16 @@
 	],
 	"upgrades": [
 		{
+			"version": "10.50.2",
+			"region":"usa",
+			"changelog": "Includes firmware versions: 10.0, 10.10, 10.20, 10.30, 10.40, 10.50.\n* Added Parameter 27 to allow disabling the LED indicator flash when scene buttons are pressed.\n* Removed the delay in turning on connected lights via the physical switch (relay button) when Central Scene Control is disabled for the relay button.\n* Bug fix: Rapidly pressing the relay button 5 times no longer cycles through values in Parameter 19.",
+			"url": "https://www.getzooz.com/firmware/ZEN32_V10R50.gbl",
+			"integrity": "sha256:155b6e8cde83fbbdff3f2be63f17458b44036019f3e0c15b7001ec922c0c86bf"
+		},
+		{
 			"version": "10.40.2",
-			"changelog": "Includes firmware versions: 10.0, 10.10, 10.20, 10.30, 10.40.\n* Added parameter 25 - Association Reports. \n* Added parameter 26 - Enable the scene control from the momentary switch in a 3-way installation.\n* Added manual button function to enable/disable the relay (smart bulb mode).\n* Added new colors for the LED indicators in parameters 6-10 - magenta, yellow, and cyan.\n* Improved Direct Association for the basic set on/off functionality. ",
+			"region":"usa",
+			"changelog": "Includes firmware versions: 10.0, 10.10, 10.20, 10.30, 10.40.\n* Added parameter 25 - Association Reports. \n* Added parameter 26 - Enable the scene control from the momentary switch in a 3-way installation.\n* Added manual button function to enable/disable the relay (smart bulb mode).\n* Added new colors for the LED indicators in parameters 6-10 - magenta, yellow, and cyan.\n* Improved Direct Association for the basic set on/off functionality.",
 			"url": "https://www.getzooz.com/firmware/ZEN32_V10R40.gbl",
 			"integrity": "sha256:61ba7ad0472e73655d81b4f540fbd37819a528cf22e0f6dc9284d8a25f655531"
 		}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->