### PR TITLE
Add Zooz ZSE11 2.10.0 (800LR) and 1.30 firmware updates

### DIFF
--- a/firmwares/zooz/ZSE11-V01.json
+++ b/firmwares/zooz/ZSE11-V01.json
@@ -15,7 +15,7 @@
 	"upgrades": [
 		{
 			"version": "1.30",
-			"changelog": "Includes firmware versions: 1.10, 1.11, 1.30.\n*  Fixed an issue with S2 Authenticated security inclusion.",
+			"changelog": "Includes firmware versions: 1.10, 1.11, 1.30.\n* Fixed an issue with S2 Authenticated security inclusion.",
 			"url": "https://www.getzooz.com/firmware/ZSE11_FW_V1_30.otz",
 			"integrity": "sha256:af540aa97c1c32b8fb9dc18562c670424a84909a36c89de80eeda199e7ad917a"
 		}

--- a/firmwares/zooz/ZSE11-V02-800-LR.json
+++ b/firmwares/zooz/ZSE11-V02-800-LR.json
@@ -15,7 +15,7 @@
 	"upgrades": [
 		{
 			"version": "2.10.0",
-			"changelog": "Includes firmware versions: 2.0, 2.10.\n*  Resolved an issue where setting the Humidity Offset to a value below 100 would incorrectly display 0%. For example, entering [95] resulted in a 0% humidity reading.\n*  Fixed a bug that caused the sensor to report negative lux values under certain conditions on specific platforms.\n*  Updated parameter names and short descriptions in the Configuration Command Class for improved clarity and consistency.",
+			"changelog": "Includes firmware versions: 2.0, 2.10.\n* Resolved an issue where setting the Humidity Offset to a value below 100 would incorrectly display 0%. For example, entering [95] resulted in a 0% humidity reading.\n* Fixed a bug that caused the sensor to report negative lux values under certain conditions on specific platforms.\n* Updated parameter names and short descriptions in the Configuration Command Class for improved clarity and consistency.",
 			"url": "https://www.getzooz.com/firmware/ZSE11_V02R10.gbl",
 			"integrity": "sha256:b2d16fe4912085f191ff7e176d16684e8d4be2a095be95b875e29e98d13da42e"
 		}

--- a/firmwares/zooz/ZSE11-V02-800-LR.json
+++ b/firmwares/zooz/ZSE11-V02-800-LR.json
@@ -1,0 +1,23 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZSE11",
+			"manufacturerId": "0x027a",
+			"productType": "0x0201",
+			"productId": "0x0006",
+			"firmwareVersion": {
+				"min": "2.10",
+				"max": "2.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "2.10.0",
+			"changelog": "Includes firmware versions: 2.0, 2.10.\n*  Resolved an issue where setting the Humidity Offset to a value below 100 would incorrectly display 0%. For example, entering [95] resulted in a 0% humidity reading.\n*  Fixed a bug that caused the sensor to report negative lux values under certain conditions on specific platforms.\n*  Updated parameter names and short descriptions in the Configuration Command Class for improved clarity and consistency.",
+			"url": "https://www.getzooz.com/firmware/ZSE11_V02R10.gbl",
+			"integrity": "sha256:b2d16fe4912085f191ff7e176d16684e8d4be2a095be95b875e29e98d13da42e"
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->