### PR TITLE
Zooz ZAC93 LR GPIO Firmware Upgrades

### DIFF
--- a/firmwares/zooz/ZAC93_LR.json
+++ b/firmwares/zooz/ZAC93_LR.json
@@ -1,0 +1,31 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZAC93",
+			"manufacturerId": "0x027a",
+			"productType": "0x0004",
+			"productId": "0x0611",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "2.10"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "2.10",
+			"region": "usa",
+			"changelog": "Based on Z-Wave SDK version 7.23.2 (read full release notes from Silicon Labs here)\nAdded LED indicator feature: Solid Red when powered ON and blinking Red when receiving commands.\nAdded Z-Wave Long Range support for Europe",
+			"url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.23.2_US-LR_V02R10.gbl",
+			"integrity": "sha256:8813d3039682543f1fdb0407814200b4ba1d45e710778c8825197e6963a15dc6"
+		},
+		{
+			"version": "2.10",
+			"region": "europe",
+			"changelog": "* Includes firmware versions: 1.0, 1.20, 1.30\n* Addressed issues with the range extender occasionally showing offline or becoming unresponsive on select platforms.",
+			"url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.23.2_EU-LR_V02R10.gbl",
+			"integrity": "sha256:e71c101f74fc2e49456368520df642713bc40a9fe0fd0bbdd20d9713c45fbe92"
+		}
+	]
+}


### PR DESCRIPTION
Adding for Zooz ZAC93 from their website here:  https://www.support.getzooz.com/kb/article/1158-zooz-ota-firmware-files/

Added new firmware versions for the Zooz ZAC93 LR GPIO module used by systems like the Home Assistant Yellow.