### PR TITLE
Add firmware updates for Shelly Wave 1, Wave 1PM, Wave 2PM

### DIFF
--- a/firmwares/shelly/qnsw-001P16.json
+++ b/firmwares/shelly/qnsw-001P16.json
@@ -14,6 +14,17 @@
 	],
 	"upgrades": [
 		{
+			"version": "13.2",
+			"changelog": "- Added Detached mode\n- Added Energy reporting precision 0,01 kWh\n- Fixed device not working properly connected DC\n- Fixed OTA signalisation\n- Fixed Binary report with normally closed\n- Fixed random power cycle (SDK issue)\n- Removed parameters 91 - 94\n- Removed Inclusion / exclussion output signalisation\n- other minor improvements and fixes",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/d9798b4b69d8adc20f7141f8b07a1843c4b87e5b/Wave_1PM/EU/Wave_1PM_800_EU_LR_20250908_1614_QLSW-001P16EU_%5Bv13.02%5D_EB201890.gbl",
+					"integrity": "sha256:863536b812ca1e034d0f45c6d66f589b6d65441535fb1e64609cbbd3b4eb0e41"
+				}
+			]
+		},
+		{
 			"version": "11.10",
 			"changelog": "- Fixed device not working with DC supply\n- Fixed OTA signalisation\n- Optimised temperature conversion table\n- Other minor improvements",
 			"region": "europe",

--- a/firmwares/shelly/qnsw-001X16.json
+++ b/firmwares/shelly/qnsw-001X16.json
@@ -14,6 +14,17 @@
 	],
 	"upgrades": [
 		{
+			"version": "13.0",
+			"changelog": "Added - Detached mode\n- Fixed OTA signalisation\n- Fixed Binary report with normally closed\n- Fixed push button inclusion / exclussion\n -other minor fixes",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/d9798b4b69d8adc20f7141f8b07a1843c4b87e5b/Wave_1/EU/Wave_1_800_EU_LR_20250829_1330_QLSW-001X16EU_%5Bv13.00%5D_0FE4B35C.gbl",
+					"integrity": "sha256:5dfaeb91e1d99b89f4415951b366fb7c80675a78d9cd71d5d453a317904b87e6"
+				}
+			]
+		},
+		{
 			"version": "11.5",
 			"changelog": "- optimised temperature conversion table",
 			"region": "europe",

--- a/firmwares/shelly/qnsw-002P16.json
+++ b/firmwares/shelly/qnsw-002P16.json
@@ -13,6 +13,17 @@
 		}
 	],
 	"upgrades": [
+				{
+			"version": "16.2",
+			"changelog": "- SDK with fixed dead node issue\nAdded detached mode and kWh precision set to 2 decimal points\nParameter 117 (reboot parameter)\nWatt reports when NO/NC parameter is active\nOther minor improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/cdefca11d5b87b1e4bd19d974ab2d6fced00ff81/Wave_2PM/EU/Wave_2PM_800_EU_LR_20251007_1240_QLSW-002P16EU_%5B16.02%5D_0FE4B35C.gbl",
+					"integrity": "sha256:62427889675268b6a71d5912564ec13c4032063223b4ff0c10ca154cebf12b3f"
+				}
+			]
+		},
 		{
 			"version": "15.0",
 			"changelog": "- Fix switch binary report when powered with DC\n- Fix Endpoint 2 report state change on single channel association\n- Fix supervision report for root command\n- Removed parameters no. 91, 92, 93, 94 from the FW\n- Other minor improvements",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->
Added FW updates for Shelly Wave devices Wave 1, Wave 1PM and Wave 2Pm