### PR TITLE
Release 5.51 for Enbrighten 55258

### DIFF
--- a/firmwares/enbrighten-ge/ZW4002_55258.json
+++ b/firmwares/enbrighten-ge/ZW4002_55258.json
@@ -10,33 +10,15 @@
 	],
 	"upgrades": [
 		{
-			"$if": "firmwareVersion >= 5.0",
 			"version": "5.50",
 			"changelog": "1. Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/9b5520f5056f7d3fce3fa6adc28bdaf27f8d0a68/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Smart%20Fan%20Speed%20Control%2C%20500S/5.50/ZW4002_Enbrighten-GE_55258_5.50.otz",
 			"integrity": "sha256:59ae4c4f749d3ad22b1d490e9dd0afe855bbd9914337f37a41beb56d62c638b2"
 		},
 		{
-			"$if": "firmwareVersion === 0.51",
-			"version": "5.50",
-			"channel": "beta",
-			"changelog": "ENABLE ORIGINAL BEHAVIOR",
-			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/9b5520f5056f7d3fce3fa6adc28bdaf27f8d0a68/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Smart%20Fan%20Speed%20Control%2C%20500S/5.50/ZW4002_Enbrighten-GE_55258_5.50.otz",
-			"integrity": "sha256:59ae4c4f749d3ad22b1d490e9dd0afe855bbd9914337f37a41beb56d62c638b2"
-		},
-		{
-			"$if": "firmwareVersion < 1.0",
-			"version": "0.51",
+			"version": "5.51",
 			"changelog": "1. Added parameter 3 (adjustable LED behavior)\n2. Added parameter 84 (factory reset)\n3. Added experimental parameter 40 (fan speed ramp rate)\n4. Update devkit to 6.84.00",
-			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/a628c1b745b96b187e61c15437d02074302d369a/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/0.51%20(Latest%2C%20Beta)/ZW4002_Enbrighten-GE_55258_0.51.otz",
-			"integrity": "sha256:f35c8babf074bbbc79466ba62cc5e6d11552dfa803c818abdc5624ab9f80e553"
-		},
-		{
-			"$if": "firmwareVersion === 5.50",
-			"version": "0.51",
-			"channel": "beta",
-			"changelog": "1. Added parameter 3 (adjustable LED behavior)\n2. Added parameter 84 (factory reset)\n3. Added experimental parameter 40 (fan speed ramp rate)\n4. Update devkit to 6.84.00",
-			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/a628c1b745b96b187e61c15437d02074302d369a/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/0.51%20(Latest%2C%20Beta)/ZW4002_Enbrighten-GE_55258_0.51.otz",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/93cd6e47e554a16d6e6659b60bc9d54cc2a92aa6/zwave/Enbrighten-GE/ZW4002/55258%20-%20In-Wall%20Fan%20Speed%20Control%2C%20500S/5.51/ZW4002_Enbrighten-GE_55258_5.51.otz",
 			"integrity": "sha256:f35c8babf074bbbc79466ba62cc5e6d11552dfa803c818abdc5624ab9f80e553"
 		}
 	]


### PR DESCRIPTION
Version 5.51 was released which was formerly the 0.51 beta.  I deleted all the conditionals added from the beta commit and just updated the version number and link.  Let me know if this is not the right approach.