### PR TITLE
Add EU option of Zooz ZSE42 V02 version 2.30.0

### DIFF
--- a/firmwares/zooz/ZSE42-V02.json
+++ b/firmwares/zooz/ZSE42-V02.json
@@ -21,6 +21,13 @@
 			"integrity": "sha256:1639d3d43c7089dfb1f0bbc42091349abf4c073fbe4c80d6fe362abac9bb586c"
 		},
 		{
+			"version": "2.30.0",
+			"region": "europe",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30\n* Corrected the behavior of parameter 5 for Basic Set Commands with Value 3 - Absence of water, send Basic Set for On, and Value 4 - Presence of water, send Basic Set for Off.",
+			"url": "https://www.getzooz.com/firmware/ZSE42_V02R30_EU.gbl",
+			"integrity": "sha256:98b241d916fd5479574df10825d7d4e2d8b417d214e06469a3591c6bddb6fb73"
+		},
+		{
 			"version": "2.20.0",
 			"region": "usa",
 			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20\n* Updated parameter 5 for Basic Set Commands with Value 3 - Basic Set for On and Value 4 - Basic Set for Off.",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->