### PR TITLE
Update: Zooz ZEN54 version 1.60.0 US and EU

### DIFF
--- a/firmwares/zooz/ZEN54.json
+++ b/firmwares/zooz/ZEN54.json
@@ -17,7 +17,7 @@
 			"version": "1.60.0",
 			"changelog": "Includes firmware versions: 1.0, 1.20, 1.30, 1.40, 1.50, 1.60.\n* Fixed: A bug (introduced in 1.50 firmware) affecting Home Assistant and Z-Wave JS users, where the dimmer part was not correctly updating. Both target value and current value now report as expected.",
 			"region": "usa",
-			"url": "npx @zwave-js/firmware-integrity https://www.getzooz.com/firmware/ZEN54_V01R60_US.gbl",
+			"url": "https://www.getzooz.com/firmware/ZEN54_V01R60_US.gbl",
 			"integrity": "sha256:f0f9e9d5aa6bde57d191927deb288d78f6ae1b086338ef3e56508ec91d68eebd"
 		},
 		{


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->