### PR TITLE
Update: Zooz ZEN73 version 2.40.0 US

### DIFF
--- a/firmwares/zooz/ZEN73-V02-800-LR.json
+++ b/firmwares/zooz/ZEN73-V02-800-LR.json
@@ -16,7 +16,7 @@
 		{
 			"version": "2.40.0",
 			"region": "usa",
-			"changelog": "* Includes firmware versions: 2.10, 2.20, 2.30, 2.40.\n* Improved the delay from the mechanical switch in 3/4-way installations.\n* Added new parameters: 19 - Scene Control Multi-Tap and 20 - LED Indicator Multi-Color.\n* Optimized Z-Wave reporting behavior: when Basic Set, Binary Set, and Multilevel set commands are sent from the Z-Wave controller (Lifeline), the device will no longer send redundant report or notification commands back to the controller.",
+			"changelog": "* Includes firmware versions: 2.10, 2.20, 2.30, 2.40.\n* Improved the delay from the mechanical switch in 3/4-way installations.\n* Added new parameters: 19 - Scene Control Multi-Tap and 20 - LED Indicator Multi-Color.\n* Optimized Z-Wave reporting behavior: when Basic Set, Binary Switch Set, and Multilevel Switch Set commands are sent from the Z-Wave controller (Lifeline), the device will no longer send redundant report or notification commands back to the controller.",
 			"url": "https://www.getzooz.com/firmware/ZEN73_V02R40.gbl",
 			"integrity": "sha256:96fd4fa2fb43dcdc81e690acc4b5fd2ac5291de6ddc6123336edbf2765825754"
 		},


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->