### PR TITLE
Add: Zooz ZEN35 800 LR version 1.20.0 US

### DIFF
--- a/firmwares/zooz/ZEN35-V01-800-LR.json
+++ b/firmwares/zooz/ZEN35-V01-800-LR.json
@@ -1,0 +1,24 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZEN35",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xa018",
+			"firmwareVersion": {
+				"min": "1.0",
+				"max": "1.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.20.0",
+			"region":"usa",
+			"changelog": "Includes firmware versions: 1.0, 1.10, 1.20.\n* Optimized Z-Wave reporting behavior: when Basic Set, Binary Set, and Multilevel set commands are sent from the Z-Wave controller (Lifeline), the device will no longer send redundant report or notification commands back to the controller.",
+			"url": "https://www.getzooz.com/firmware/ZEN35_V01R20.gbl",
+			"integrity": "sha256:0fee1e59628fb00a2af1dabe35a19e0fda0b60a653666cc8ce08be2738c5adde"
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->