### PR TITLE
Add Zooz ZEN74 V02 800 LR, firmware version 2.4.0, US

### DIFF
--- a/firmwares/zooz/ZEN74-V02-800-LR.json
+++ b/firmwares/zooz/ZEN74-V02-800-LR.json
@@ -16,7 +16,7 @@
 		{
 			"version": "2.40.0",
 			"region": "usa",
-			"changelog": "* Includes firmware versions: 2.10, 2.20, 2.30,2.40.\n* Added new parameters: 35 - Scene Control Multi-Tap, 36 - Gamma Factor, and 37 - LED Indicator Multi-Color.\n* Optimized Z-Wave reporting behavior: when Basic Set, Binary Set, and Multilevel set commands are sent from the Z-Wave controller (Lifeline), the device will no longer send redundant report or notification commands back to the controller.\n* Improved the delay from the mechanical switch in 3/4-way installations.",
+			"changelog": "* Includes firmware versions: 2.10, 2.20, 2.30, 2.40.\n* Added new parameters: 35 - Scene Control Multi-Tap, 36 - Gamma Factor, and 37 - LED Indicator Multi-Color.\n* Optimized Z-Wave reporting behavior: when Basic Set, Binary Set, and Multilevel set commands are sent from the Z-Wave controller (Lifeline), the device will no longer send redundant report or notification commands back to the controller.\n* Improved the delay from the mechanical switch in 3/4-way installations.",
 			"url": "https://www.getzooz.com/firmware/ZEN74_V02R40.gbl",
 			"integrity": "sha256:1b0ae3c8a563249552bdec30af31797a6c6c5cf722a7256b5719cc0f0476c5a7"
 		},


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->