### PR TITLE
Add Zooz ZAC93-V01, US and EU, firmware 1.50

### DIFF
--- a/firmwares/zooz/ZAC93-V01.json
+++ b/firmwares/zooz/ZAC93-V01.json
@@ -16,16 +16,16 @@
     {
       "version": "1.50.0",
       "region": "usa",
-      "changelog": "Based on Z-Wave SDK Version 7.22.1",
+      "changelog": "* Includes firmware versions: 1.01, 1.03, 1.04, 1.10, 1.20, 1.30, 1.40, 1.50\n* Based on Z-Wave SDK Version 7.22.1",
       "url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_US-LR_V01R50.gbl",
-      "integrity": "sha256:3a9f66aaba187da5f28b46a054368e129ce5a39b2b19c890e36a7c1f2bb9b1a6"
+      "integrity": "sha256:43f0ae779ed2dd465ad5c31ca31c62e85d66932579fc13bf94115793418043db"
     },
     {
       "version": "1.50.0",
       "region": "europe",
-      "changelog": "Based on Z-Wave SDK Version 7.22.1",
-      "url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_EU-V01R50.zip",
-      "integrity": "sha256:2097c4bb1cb3f6ed19a5b9ed8c6ae2c631fbb17e54cee6bb145f31cfef32da06"
+      "changelog": "* Includes firmware versions: 1.01, 1.03, 1.04, 1.10, 1.20, 1.30, 1.40, 1.50\n* Based on Z-Wave SDK Version 7.22.1",
+      "url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_EU_V01R50.gbl",
+      "integrity": "sha256:36f09431f8160d2769df2523d0fee2bd30c53934e2836b4e9500c5b7ce40386a"
     }
   ]
 }

--- a/firmwares/zooz/ZAC93-V01.json
+++ b/firmwares/zooz/ZAC93-V01.json
@@ -1,0 +1,31 @@
+{
+  "devices": [
+    {
+      "brand": "Zooz",
+      "model": "ZAC93",
+      "manufacturerId": "0x027a",
+      "productType": "0x0004",
+      "productId": "0x0611",
+      "firmwareVersion": {
+        "min": "0.0",
+        "max": "1.255"
+      }
+    }
+  ],
+  "upgrades": [
+    {
+      "version": "1.50.0",
+      "region": "usa",
+      "changelog": "Based on Z-Wave SDK Version 7.22.1",
+      "url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_US-LR_V01R50.zip",
+      "integrity": "sha256:3a9f66aaba187da5f28b46a054368e129ce5a39b2b19c890e36a7c1f2bb9b1a6"
+    },
+    {
+      "version": "1.50.0",
+      "region": "europe",
+      "changelog": "Based on Z-Wave SDK Version 7.22.1",
+      "url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_EU-V01R50.zip",
+      "integrity": "sha256:2097c4bb1cb3f6ed19a5b9ed8c6ae2c631fbb17e54cee6bb145f31cfef32da06"
+    }
+  ]
+}

--- a/firmwares/zooz/ZAC93-V01.json
+++ b/firmwares/zooz/ZAC93-V01.json
@@ -17,7 +17,7 @@
       "version": "1.50.0",
       "region": "usa",
       "changelog": "Based on Z-Wave SDK Version 7.22.1",
-      "url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_US-LR_V01R50.zip",
+      "url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_US-LR_V01R50.gbl",
       "integrity": "sha256:3a9f66aaba187da5f28b46a054368e129ce5a39b2b19c890e36a7c1f2bb9b1a6"
     },
     {

--- a/firmwares/zooz/ZAC93-V01.json
+++ b/firmwares/zooz/ZAC93-V01.json
@@ -1,31 +1,31 @@
 {
-  "devices": [
-    {
-      "brand": "Zooz",
-      "model": "ZAC93",
-      "manufacturerId": "0x027a",
-      "productType": "0x0004",
-      "productId": "0x0611",
-      "firmwareVersion": {
-        "min": "0.0",
-        "max": "1.255"
-      }
-    }
-  ],
-  "upgrades": [
-    {
-      "version": "1.50.0",
-      "region": "usa",
-      "changelog": "Based on Z-Wave SDK Version 7.22.1",
-      "url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_US-LR_V01R50.zip",
-      "integrity": "sha256:3a9f66aaba187da5f28b46a054368e129ce5a39b2b19c890e36a7c1f2bb9b1a6"
-    },
-    {
-      "version": "1.50.0",
-      "region": "europe",
-      "changelog": "Based on Z-Wave SDK Version 7.22.1",
-      "url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_EU-V01R50.zip",
-      "integrity": "sha256:2097c4bb1cb3f6ed19a5b9ed8c6ae2c631fbb17e54cee6bb145f31cfef32da06"
-    }
-  ]
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZAC93",
+			"manufacturerId": "0x027a",
+			"productType": "0x0004",
+			"productId": "0x0611",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "1.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.50.0",
+			"region": "usa",
+			"changelog": "- Includes firmware versions: 1.01, 1.03, 1.04, 1.10, 1.20, 1.30, 1.40, 1.50\n- Based on Z-Wave SDK Version 7.22.1",
+			"url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_US-LR_V01R50.zip",
+			"integrity": "sha256:3a9f66aaba187da5f28b46a054368e129ce5a39b2b19c890e36a7c1f2bb9b1a6"
+		},
+		{
+			"version": "1.50.0",
+			"region": "europe",
+			"changelog": "- Includes firmware versions: 1.01, 1.03, 1.04, 1.10, 1.20, 1.30, 1.40, 1.50\n- Based on Z-Wave SDK Version 7.22.1",
+			"url": "https://www.getzooz.com/firmware/ZAC93_SDK_7.22.1_EU-V01R50.zip",
+			"integrity": "sha256:2097c4bb1cb3f6ed19a5b9ed8c6ae2c631fbb17e54cee6bb145f31cfef32da06"
+		}
+	]
 }


### PR DESCRIPTION
The ZAC93 (v2.x) firmware was added in #183 and later removed in #215. Zooz website states:

> Firmware version 2.10 has shown compatibility issues with certain updates, so we have temporarily removed it from our files to prevent issues, which means it is also not available via Home Assistant directly as this time. Please use the above file instead. We’ve reached out to Silicon Labs, the developer and provider of controller firmware, to resolve the problem.

The firmware now at https://www.support.getzooz.com/kb/article/1158-zooz-ota-firmware-files/ is v1.50. At the moment, zwave-js reports this for me:

> 800 series controller firmwares based on Z-Wave SDKs before 7.22.1 are plagued by a variety of bugs causing instability of the controller and/or the mesh. It is strongly recommended to update to a firmware based on version 7.22.1 or later.

I cannot update the SDK without this firmware.

@zooz-git 