### PR TITLE
Add: Zooz ZEN15 800 LR version 2.30.0 US

### DIFF
--- a/firmwares/zooz/ZEN15-V02.json
+++ b/firmwares/zooz/ZEN15-V02.json
@@ -14,6 +14,13 @@
 	],
 	"upgrades": [
 		{
+			"version": "2.30.0",
+			"region": "usa",
+			"changelog": "* N/A",
+			"url": "https://www.getzooz.com/firmware/ZEN15_V02R30_US.gbl",
+			"integrity": "sha256:e4bd1bc617106f272fe0c77ed09cbaee096c7981748c697410d45aea48e8d044"
+		},
+		{
 			"version": "2.20.0",
 			"region": "usa",
 			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20\n* Updated parameter names and short descriptions in the Configuration Command Class to match the Advanced Setting",


### PR DESCRIPTION
Add firmware version 2.30.0 US to Zooz ZEN15 800 LR. No release notes available at time of PR. Firmware file posted and avaiable on Zooz web page. 
@zooz-git Are notes available for this release version?