### PR TITLE
Add Aeotec ZW078-A/B/C,  firmware version 3.28

### DIFF
--- a/firmwares/aeotec/ZW078-A.json
+++ b/firmwares/aeotec/ZW078-A.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW078-A", //Heavy Duty Smart Switch
+			"manufacturerId": "0x0086",
+			"productType": "0x0103", //US
+			"productId": "0x004e"
+		}
+	],
+	"upgrades": [ 
+		//firmware V3.28
+		{
+			"$if": "firmwareVersion >= 3.20 && firmwareVersion < 3.28",
+			"version": "3.28",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Minor logic refinement for kWh calculation\n* Threshold Parameter fix",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://github.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/blob/main/Series_500/ZW078_HDSSGen5_US_V3_28.otz",
+					"integrity": "sha256:8835e85438c7bbb8805877e69b8b15d5a6f7d8b4e876bf32a452eb315e35cc25"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW078-B.json
+++ b/firmwares/aeotec/ZW078-B.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW078-B", //Heavy Duty Smart Switch
+			"manufacturerId": "0x0086",
+			"productType": "0x0203", //AU
+			"productId": "0x004e"
+		}
+	],
+	"upgrades": [ 
+		//firmware V3.28
+		{
+			"$if": "firmwareVersion >= 3.20 && firmwareVersion < 3.28",
+			"version": "3.28",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Minor logic refinement for kWh calculation\n* Threshold Parameter fix",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://github.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/blob/main/Series_500/ZW078_HDSSGen5_AU_V3_28.otz",
+					"integrity": "sha256:954a8b04338e2db48140175670331256f0f099957650e37deedc07330968f04e"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW078-C.json
+++ b/firmwares/aeotec/ZW078-C.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW078-C", //Heavy Duty Smart Switch
+			"manufacturerId": "0x0086",
+			"productType": "0x0003", //EU
+			"productId": "0x004e"
+		}
+	],
+	"upgrades": [ 
+		//firmware V3.28
+		{
+			"$if": "firmwareVersion >= 3.20 && firmwareVersion < 3.28",
+			"version": "3.28",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Minor logic refinement for kWh calculation\n* Threshold Parameter fix",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://github.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/blob/main/Series_500/ZW078_HDSSGen5_EU_V3_28.otz",
+					"integrity": "sha256:91ed816a5df1d0f1fa6562b471b33556b22e950d7f99f1557120edc35903c722"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->