### PR TITLE
Add updates for Shelly Wave Dimmer and Wave 2PM, fixed wrong FW number in Wave Door/Window

### DIFF
--- a/firmwares/shelly/qldm-0A101.json
+++ b/firmwares/shelly/qldm-0A101.json
@@ -1,0 +1,39 @@
+{
+	"devices": [
+		{
+			"brand": "Shelly",
+			"model": "Wave Dimmer",
+			"manufacturerId": "0x0460",
+			"productType": "0x0001",
+			"productId": "0x0083",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "12.3",
+			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working propely\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Fix Detached mode Binary Switch when SW set to toggle\n- Improved Mosfet PWM\n- Other minor improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/c5dd3cabe192c3e6eb39e8df830c4df5e8387090/Wave_Dimmer/EU/Wave_Dimmer_800_EU_LR_20251219_1342_QLDM-0A101EUL_%5B12.03%5D_9DD2F96C.gbl",
+					"integrity": "sha256:6d073e947be494b9e4b2c01dd3b5435940d27a0ceb8d882ec59607f1fb6e2b38"
+				}
+			]
+		},
+		{
+			"version": "12.3",
+			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working propely\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Fix Detached mode Binary Switch when SW set to toggle\n- Improved Mosfet PWM\n- Other minor improvements",
+			"region": "usa",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/c5dd3cabe192c3e6eb39e8df830c4df5e8387090/Wave_Dimmer/US/Wave_Dimmer_800_US_LR_20260108_0951_QLDM-0A101USL_%5B12.03%5D_EB201890.gbl",
+					"integrity": "sha256:91e90717160b12a60d0e9a5fb9f44c58df19fc1ef693928cbc095dd66da317e5"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/shelly/qldw-002FC.json
+++ b/firmwares/shelly/qldw-002FC.json
@@ -14,7 +14,7 @@
 	],
 	"upgrades": [
 		{
-			"version": "10.9",
+			"version": "11.9",
 			"changelog": "- Fixed Z-Wave node info during inclusion\n- Fixed parameter 157 - Default value\n- Fixed no comunication after inclusion state change\n- Fixed inclination bug\n- Improved Angle measuring\n- other minor improvements ",
 			"region": "europe",
 			"files": [

--- a/firmwares/shelly/qnsw-002P16.json
+++ b/firmwares/shelly/qnsw-002P16.json
@@ -14,6 +14,39 @@
 	],
 	"upgrades": [
 		{
+			"version": "16.5",
+			"changelog": "- Detached mode SW2 fixed\n- External switches exclusion disabled\n- Fixed Multichannel Association on EP 2",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/c5dd3cabe192c3e6eb39e8df830c4df5e8387090/Wave_2PM/EU/Wave_2PM_800_EU_LR_20260116_1304_QLSW-002P16EU_%5B16.05%5D_2144DF1C.gbl",
+					"integrity": "sha256:24849f9f2863ce782538fbc04d9c83e8a871ea1594d976d5426b9f38191b7df1"
+				}
+			]
+		},
+		{
+			"version": "16.5",
+			"changelog": "- Detached mode SW2 fixed\n- External switches exclusion disabled\n- Fixed Multichannel Association on EP 2",
+			"region": "usa",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/c5dd3cabe192c3e6eb39e8df830c4df5e8387090/Wave_2PM/US/Wave_2PM_800_US_LR_20260116_1304_QLSW-002P14US_%5B16.05%5D_9DD2F96C.gbl",
+					"integrity": "sha256:b0a1c3d151b6f18b8530f3bcd141383c67796104351a77898d94aed1722ec12d"
+				}
+			]
+		},
+		{
+			"version": "16.5",
+			"changelog": "- Detached mode SW2 fixed\n- External switches exclusion disabled\n- Fixed Multichannel Association on EP 2",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/c5dd3cabe192c3e6eb39e8df830c4df5e8387090/Wave_2PM/ANZ/Wave_2PM_800_ANZ_20260116_1304_QNSW-002P16AU_%5B16.05%5D_2144DF1C.gbl",
+					"integrity": "sha256:5f1365fc51c7e20e34fa7c9a9a3f3b7ec39ac26dd2d67de0e81723cf025cbf60"
+				}
+			]
+		},
+		{
 			"version": "16.2",
 			"changelog": "- SDK with fixed dead node issue\nAdded detached mode and kWh precision set to 2 decimal points\nParameter 117 (reboot parameter)\nWatt reports when NO/NC parameter is active\nOther minor improvements",
 			"region": "europe",


### PR DESCRIPTION
Add updates for Shelly Wave Dimmer and Wave 2PM, fixed wrong FW number in Wave Door/Window

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->