### PR TITLE
Add Aeotec Siren Gen5 Firmware v3.28

### DIFF
--- a/firmwares/aeotec/ZW080-A.json
+++ b/firmwares/aeotec/ZW080-A.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW080-A", //Siren Gen5 US
+			"manufacturerId": "0x0086",
+			"productType": "0x0104", //US
+			"productId": "0x0050",
+		}
+	],
+	"upgrades": [ 
+		//firmware 3.28
+		{
+			"$if": "firmwareVersion >= 3.0 && firmwareVersion < 3.28",
+			"version": "3.28",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Parameter 37 refinement",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW080_Siren_Gen5_US_B_V3_28.otz",
+					"integrity": "sha256:ccd72fa68c49bc36c4dce6535ca2cff8c8705ddff280df4d582a219b5824c26f"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW080-B.json
+++ b/firmwares/aeotec/ZW080-B.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW080-B", //Siren Gen5 AU
+			"manufacturerId": "0x0086",
+			"productType": "0x0204", //AU
+			"productId": "0x0050",
+		}
+	],
+	"upgrades": [ 
+		//firmware 3.28
+		{
+			"$if": "firmwareVersion >= 3.0 && firmwareVersion < 3.28",
+			"version": "3.28",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Parameter 37 refinement",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW080_Siren_Gen5_AU_B_V3_28.otz",
+					"integrity": "sha256:2f6388c3dd4cc69e8692e101cff2a1cf9530105ee7e32b12a184c8c2102e6e5e"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW080-C.json
+++ b/firmwares/aeotec/ZW080-C.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW080-C", //Siren Gen5 EU
+			"manufacturerId": "0x0086",
+			"productType": "0x0004", //EU
+			"productId": "0x0050",
+		}
+	],
+	"upgrades": [ 
+		//firmware 3.28
+		{
+			"$if": "firmwareVersion >= 3.0 && firmwareVersion < 3.28",
+			"version": "3.28",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Parameter 37 refinement",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW080_Siren_Gen5_EU_B_V3_28.otz",
+					"integrity": "sha256:d55fc0e979405aea48bbf98c63c2465c3de639026b9ccf8d694402730dd5a61a"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->