### PR TITLE
Add Smart Switch 6 EU/AU Firmware v1.04, US v1.07

### DIFF
--- a/firmwares/aeotec/ZW096-A.json
+++ b/firmwares/aeotec/ZW096-A.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW096-A", //Smart Switch 6 ZW096 and ZW110
+			"manufacturerId": "0x0086",
+			"productType": "0x0103", //US
+			"productId": "0x0060"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.07
+		{
+			"$if": "firmwareVersion >= 1.00 && firmwareVersion < 1.07",
+			"version": "1.07",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Add Color CC for night light mode\n* Improved Meter CC\n* Firmware for both ZW096 and ZW110.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW096_ZW110_Smart_Switch_6_US_V1_07.otz",
+					"integrity": "sha256:ca6378fe090da6a574a4b69f09a640d032d06b5b1f96b6ff14ef0d2c725340ca"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW096-B.json
+++ b/firmwares/aeotec/ZW096-B.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW096-B", //Smart Switch 6 ZW096 and ZW110
+			"manufacturerId": "0x0086",
+			"productType": "0x0203", //AU
+			"productId": "0x0060"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.04
+		{
+			"$if": "firmwareVersion >= 1.00 && firmwareVersion < 1.04",
+			"version": "1.04",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Add Color CC for night light mode\n* Improved Meter CC\n* Firmware for both ZW096 and ZW110.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW096_ZW110_Smart_Switch_6_AU_V1_04.otz",
+					"integrity": "sha256:1427ba6422895f3813d1b617f298a84d43b00a5d2504b407c2ca9ebc318e5cf8"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW096-C.json
+++ b/firmwares/aeotec/ZW096-C.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW096-C", //Smart Switch 6 ZW096 and ZW110
+			"manufacturerId": "0x0086",
+			"productType": "0x0003", //EU
+			"productId": "0x0060"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.04
+		{
+			"$if": "firmwareVersion >= 1.00 && firmwareVersion < 1.04",
+			"version": "1.04",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Add Color CC for night light mode\n* Improved Meter CC\n* Firmware for both ZW096 and ZW110.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW096_ZW110_Smart_Switch_6_EU_V1_04.otz",
+					"integrity": "sha256:bc36d03d511e349b7907ed1cb09a01fdcdf7822a858a5ea3bc47056e24b9266a"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Firmware V1.04 EU/AU is equivalent to US V1.07

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->