### PR TITLE
Add Smart Dimmer 6 Firmware V1.09 and V1.14

### DIFF
--- a/firmwares/aeotec/ZW099-A.json
+++ b/firmwares/aeotec/ZW099-A.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW099-A", //Smart Dimmer 6
+			"manufacturerId": "0x0086",
+			"productType": "0x0103", //US
+			"productId": "0x0063"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.14
+		{
+			"$if": "firmwareVersion >= 1.00 && firmwareVersion < 1.14",
+			"version": "1.09",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Switch Multilevel V2 added duration variable.\n* LED Indicator fix (V1.03).\n* Improved dimming stability.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW099_Smart_Dimmer_6_US_A_V1_14.otz",
+					"integrity": "sha256:b2dd35888e454699cc36d29dae60a46094e9525a623a2e5fb93fbbf18fddeb40"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW099-B.json
+++ b/firmwares/aeotec/ZW099-B.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW099-B", //Smart Dimmer 6
+			"manufacturerId": "0x0086",
+			"productType": "0x0203", //AU
+			"productId": "0x0063"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.09
+		{
+			"$if": "firmwareVersion >= 1.00 && firmwareVersion < 1.09",
+			"version": "1.09",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Switch Multilevel V2 added duration variable.\n* LED Indicator fix (V1.03).\n* Improved dimming stability.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW099_Smart_Dimmer_6_AU_A_V1_09.otz",
+					"integrity": "sha256:182e08d94f06d6432fd56db394127dd2f860da9a14b0377d85a5d074feffd15b"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW099-C.json
+++ b/firmwares/aeotec/ZW099-C.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW099-C", //Smart Dimmer 6
+			"manufacturerId": "0x0086",
+			"productType": "0x0003", //EU
+			"productId": "0x0063"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.09
+		{
+			"$if": "firmwareVersion >= 1.00 && firmwareVersion < 1.09",
+			"version": "1.09",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Switch Multilevel V2 added duration variable.\n* LED Indicator fix (V1.03).\n* Improved dimming stability.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW099_Smart_Dimmer_6_EU_A_V1_09.otz",
+					"integrity": "sha256:646b985c8a017cccbe6d52b4cd8d4e3709212a8de3042fd8426be87b6f3723c4"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
V1.09 EU/AU is equivalent to V1.14 US

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->