### PR TITLE
Add Aeotec Range Extender 7 Firmware v1.05

### DIFF
--- a/firmwares/aeotec/ZW117-A.json
+++ b/firmwares/aeotec/ZW117-A.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW117-A", //Range Extender 7
+			"manufacturerId": "0x0086",
+			"productType": "0x0103", //US
+			"productId": "0x0075",
+		}
+	],
+	"upgrades": [ 
+		//firmware 1.05
+		{
+			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.5",
+			"version": "1.5",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Explorer Frames Added.\n* LED Feedback fixed.\n* Updated SDK to better support Series 700 controllers.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW117_Range_Extender_6_US_V1_05.otz",
+					"integrity": "sha256:f536131bfcbf03d7a4637aaa134fdb18763953f6aef90df29dc8359d2b283c63"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW117-B.json
+++ b/firmwares/aeotec/ZW117-B.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW117-A", //Range Extender 7
+			"manufacturerId": "0x0086",
+			"productType": "0x0203", //AU
+			"productId": "0x0075",
+		}
+	],
+	"upgrades": [ 
+		//firmware 1.05
+		{
+			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.5",
+			"version": "1.5",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Explorer Frames Added.\n* LED Feedback fixed.\n* Updated SDK to better support Series 700 controllers.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW117_Range_Extender_6_AU_V1_05.otz",
+					"integrity": "sha256:b95412f581f3536b2812e3de4dd3060625cc70d0a1ebe7bcd0b3ceedfae552e8"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW117-C.json
+++ b/firmwares/aeotec/ZW117-C.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW117-A", //Range Extender 7
+			"manufacturerId": "0x0086",
+			"productType": "0x0003", //EU
+			"productId": "0x0075",
+		}
+	],
+	"upgrades": [ 
+		//firmware 1.05
+		{
+			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.5",
+			"version": "1.5",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Explorer Frames Added.\n* LED Feedback fixed.\n* Updated SDK to better support Series 700 controllers.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW117_Range_Extender_6_EU_V1_05.otz",
+					"integrity": "sha256:b9147c0366f80648142ed04ace86cf5453768631abe4d47397c2d22484912a27"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->