### PR TITLE
Add Aeotec Door Window Sensor Gen5 Firmware v1.06

### DIFF
--- a/firmwares/aeotec/ZW120-A.json
+++ b/firmwares/aeotec/ZW120-A.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW112-A", //Door Window Sensor Gen5
+			"manufacturerId": "0x0086",
+			"productType": "0x0102", //US
+			"productId": "0x0078"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.06
+		{
+			"$if": "firmwareVersion < 1.6",
+			"version": "1.6",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Wakeup optimizations.\n* Parameter 121 support.\n* Update SDK 6.51.10.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW120_DWSG5_US_V1_06.otz",
+					"integrity": "sha256:aa366b0721f4284d588b6efc9e34ab17ee891f9b4bff1340ba3af47ffc58cd2c"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW120-B.json
+++ b/firmwares/aeotec/ZW120-B.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW112-B", //Door Window Sensor Gen5
+			"manufacturerId": "0x0086",
+			"productType": "0x0202", //AU
+			"productId": "0x0078"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.06
+		{
+			"$if": "firmwareVersion < 1.6",
+			"version": "1.6",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Wakeup optimizations.\n* Parameter 121 support.\n* Update SDK 6.51.10.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW120_DWSG5_AU_V1_06.otz",
+					"integrity": "sha256:d95a2bf314a4d5b9be8e2f61afc6ce09a446f52a601cd7e138806a0eaf7fbe2a"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW120-C.json
+++ b/firmwares/aeotec/ZW120-C.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW112-C", //Door Window Sensor Gen5
+			"manufacturerId": "0x0086",
+			"productType": "0x0002", //EU
+			"productId": "0x0078"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.06
+		{
+			"$if": "firmwareVersion < 1.6",
+			"version": "1.6",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Wakeup optimizations.\n* Parameter 121 support.\n* Update SDK 6.51.10.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW120_DWSG5_EU_V1_06.otz",
+					"integrity": "sha256:86edd8579842b20bfb2ef1aecda50add09e624650bfd56175ec00b8a8eddb9b2"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->