### PR TITLE
Add Aeotec LED Strip Firmware V1.03

### DIFF
--- a/firmwares/aeotec/ZW121-A.json
+++ b/firmwares/aeotec/ZW121-A.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW121-A", //LED Strip
+			"manufacturerId": "0x0086",
+			"productType": "0x0103", //US
+			"productId": "0x0079"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.03
+		{
+			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.3",
+			"version": "1.3",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Color Transition Accuracy\n* Colorful Mode Exit Fix.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW121_Led_Strip_US_A_V1_03.otz",
+					"integrity": "sha256:a77779a850253ef5431e1eea4962dba0ec9e7ba32d4c6a9b9085287d89600597"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW121-B.json
+++ b/firmwares/aeotec/ZW121-B.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW098-B", //LED Strip
+			"manufacturerId": "0x0086",
+			"productType": "0x0203", //AU
+			"productId": "0x0079"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.03
+		{
+			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.3",
+			"version": "1.3",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Color Transition Accuracy\n* Colorful Mode Exit Fix.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW121_Led_Strip_AU_A_V1_03.otz",
+					"integrity": "sha256:03706f332ba4ed2331de36123d3477ab1274550c46e059be53a368e8ef732870"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW121-C.json
+++ b/firmwares/aeotec/ZW121-C.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW098-C", //LED Strip
+			"manufacturerId": "0x0086",
+			"productType": "0x0003", //EU
+			"productId": "0x0079"
+		}
+	],
+	"upgrades": [ 
+		//firmware V1.03
+		{
+			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 1.3",
+			"version": "1.3",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Color Transition Accuracy\n* Colorful Mode Exit Fix.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW121_Led_Strip_EU_A_V1_03.otz",
+					"integrity": "sha256:89756fe01b4f3b263b4c7d05d4d52cb32a154bb5439d0ebd18c36b930dc8c662"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->