### PR TITLE
Add Aeotec WallMote Quad Firmware v2.03

### DIFF
--- a/firmwares/aeotec/ZW130-A.json
+++ b/firmwares/aeotec/ZW130-A.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW130-A", //WallMote Quad
+			"manufacturerId": "0x0086",
+			"productType": "0x0101", //US
+			"productId": "0x0082",
+		}
+	],
+	"upgrades": [ 
+		//firmware 2.00 to 2.03
+		{
+			"$if": "firmwareVersion >= 2.0 && firmwareVersion < 2.3",
+			"version": "2.3",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Update Central Scene CC.\n* Association Framework Fix.\n* Haptic and Visual Sync Accuracy.\n* Improved S0 Security Nonce handling.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW130_WallMoteQuad_US_A_V2.03.otz",
+					"integrity": "sha256:8319bc645ec3f68cec0dd18e2371b9dcc77eba3b97dd3517f6b37adbc6f9f6a1"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW130-B.json
+++ b/firmwares/aeotec/ZW130-B.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW130-B", //WallMote Quad
+			"manufacturerId": "0x0086",
+			"productType": "0x0201", //AU
+			"productId": "0x0082",
+		}
+	],
+	"upgrades": [ 
+		//firmware 2.00 to 2.03
+		{
+			"$if": "firmwareVersion >= 2.0 && firmwareVersion < 2.3",
+			"version": "2.3",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Update Central Scene CC.\n* Association Framework Fix.\n* Haptic and Visual Sync Accuracy.\n* Improved S0 Security Nonce handling.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW130_WallMoteQuad_AU_A_V2.03.otz",
+					"integrity": "sha256:bc7b9c1f73c098b81f26674d16f47c19933cc3e5b8095c42e5348c707eefd76f"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW130-C.json
+++ b/firmwares/aeotec/ZW130-C.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW130-C", //WallMote Quad
+			"manufacturerId": "0x0086",
+			"productType": "0x0001", //EU
+			"productId": "0x0082",
+		}
+	],
+	"upgrades": [ 
+		//firmware 2.00 to 2.03
+		{
+			"$if": "firmwareVersion >= 2.0 && firmwareVersion < 2.3",
+			"version": "2.3",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Update Central Scene CC.\n* Association Framework Fix.\n* Haptic and Visual Sync Accuracy.\n* Improved S0 Security Nonce handling.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://raw.githubusercontent.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/refs/heads/main/Series_500/ZW130_WallMoteQuad_EU_A_V2.03.otz",
+					"integrity": "sha256:75215b1f613ae4ca7343552b00f2f6c3b814d94e0c228aae382100a66276dc3c"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->