### PR TITLE
Add merge_queue trigger to test-and-release workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -7,7 +7,7 @@ on:
       # This avoids having duplicate builds in non-forked PRs
       - "main"
   pull_request: {}
-  merge_queue: {}
+  merge_group: {}
 
 # Cancel previous PR/branch runs when a new commit is pushed
 concurrency: 


### PR DESCRIPTION
This enables the CI workflow to run when PRs are added to GitHub's
merge queue, ensuring checks pass before automatic merging.

https://claude.ai/code/session_01Fm16f35tWeM3agGyE91wft