### PR TITLE
Add Aeotec Dual Nano Switch w Energy Firmware v3.2

### DIFF
--- a/firmwares/aeotec/ZW132-A.json
+++ b/firmwares/aeotec/ZW132-A.json
@@ -5,16 +5,16 @@
 			"model": "ZW132-A", //Dual Nano Switch with energy
 			"manufacturerId": "0x0086",
 			"productType": "0x0103", //US
-			"productId": "0x0084",
+			"productId": "0x0084"
 		}
 	],
-	"upgrades": [ 
+	"upgrades": [
 		//firmware 3.02
 		{
 			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 3.2",
 			"version": "3.2",
 			"channel": "stable",
-			"changelog": "Bug Fixes:\n* Performance boost.\n* Association framework fix.\n* Multichannel Reporting.\n* If updating from V2.XX or earlier, it may factory reset the Nano Switch and will require re-pairing.",
+			"changelog": "Note: If updating from V2.XX or earlier, the Nano Switch may be reset to factory settings and require re-pairing.\n\nBug Fixes:\n* Performance boost.\n* Association framework fix.\n* Multichannel Reporting.",
 			"files": [
 				{
 					"target": 0,

--- a/firmwares/aeotec/ZW132-B.json
+++ b/firmwares/aeotec/ZW132-B.json
@@ -5,16 +5,16 @@
 			"model": "ZW132-B", //Dual Nano Switch with energy
 			"manufacturerId": "0x0086",
 			"productType": "0x0203", //AU
-			"productId": "0x0084",
+			"productId": "0x0084"
 		}
 	],
-	"upgrades": [ 
+	"upgrades": [
 		//firmware 3.02
 		{
 			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 3.2",
 			"version": "3.2",
 			"channel": "stable",
-			"changelog": "Bug Fixes:\n* Performance boost.\n* Association framework fix.\n* Multichannel Reporting.\n* If updating from V2.XX or earlier, it may factory reset the Nano Switch and will require re-pairing.",
+			"changelog": "Note: If updating from V2.XX or earlier, the Nano Switch may be reset to factory settings and require re-pairing.\n\nBug Fixes:\n* Performance boost.\n* Association framework fix.\n* Multichannel Reporting.",
 			"files": [
 				{
 					"target": 0,

--- a/firmwares/aeotec/ZW132-C.json
+++ b/firmwares/aeotec/ZW132-C.json
@@ -5,16 +5,16 @@
 			"model": "ZW132-C", //Dual Nano Switch with energy
 			"manufacturerId": "0x0086",
 			"productType": "0x0003", //EU
-			"productId": "0x0084",
+			"productId": "0x0084"
 		}
 	],
-	"upgrades": [ 
+	"upgrades": [
 		//firmware 3.02
 		{
 			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 3.2",
 			"version": "3.2",
 			"channel": "stable",
-			"changelog": "Bug Fixes:\n* Performance boost.\n* Association framework fix.\n* Multichannel Reporting.\n* If updating from V2.XX or earlier, it may factory reset the Nano Switch and will require re-pairing.",
+			"changelog": "Note: If updating from V2.XX or earlier, the Nano Switch may be reset to factory settings and require re-pairing.\n\nBug Fixes:\n* Performance boost.\n* Association framework fix.\n* Multichannel Reporting.",
 			"files": [
 				{
 					"target": 0,


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->