### PR TITLE
Add Aeotec Nano Switch Firmware V3.01

### DIFF
--- a/firmwares/aeotec/ZW139-A.json
+++ b/firmwares/aeotec/ZW139-A.json
@@ -5,16 +5,16 @@
 			"model": "ZW139-A", //Nano Switch
 			"manufacturerId": "0x0086",
 			"productType": "0x0103", //US
-			"productId": "0x008b",
+			"productId": "0x008b"
 		}
 	],
-	"upgrades": [ 
+	"upgrades": [
 		//firmware 3.01
 		{
 			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 3.1",
 			"version": "3.1",
 			"channel": "stable",
-			"changelog": "Bug Fixes:\n* (V2.00) External Switch Auto Detection.\n* Switch state report speed.\n* Better WallSwipe IR Filtering.\n* Improved NVM Reliability.\n* If updating from V2.XX or earlier, it may factory reset the Nano Switch and will require re-pairing.",
+			"changelog": "Note: If updating from V2.XX or earlier, the Nano Switch may be reset to factory settings and require re-pairing.\n\nBug Fixes:\n* (V2.00) External Switch Auto Detection.\n* Switch state report speed.\n* Better WallSwipe IR Filtering.\n* Improved NVM Reliability.",
 			"files": [
 				{
 					"target": 0,

--- a/firmwares/aeotec/ZW139-B.json
+++ b/firmwares/aeotec/ZW139-B.json
@@ -5,16 +5,16 @@
 			"model": "ZW139-B", //Nano Switch
 			"manufacturerId": "0x0086",
 			"productType": "0x0203", //AU
-			"productId": "0x008b",
+			"productId": "0x008b"
 		}
 	],
-	"upgrades": [ 
+	"upgrades": [
 		//firmware 3.01
 		{
 			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 3.1",
 			"version": "3.1",
 			"channel": "stable",
-			"changelog": "Bug Fixes:\n* (V2.00) External Switch Auto Detection.\n* Switch state report speed.\n* Better WallSwipe IR Filtering.\n* Improved NVM Reliability.\n* If updating from V2.XX or earlier, it may factory reset the Nano Switch and will require re-pairing.",
+			"changelog": "Note: If updating from V2.XX or earlier, the Nano Switch may be reset to factory settings and require re-pairing.\n\nBug Fixes:\n* (V2.00) External Switch Auto Detection.\n* Switch state report speed.\n* Better WallSwipe IR Filtering.\n* Improved NVM Reliability.",
 			"files": [
 				{
 					"target": 0,

--- a/firmwares/aeotec/ZW139-C.json
+++ b/firmwares/aeotec/ZW139-C.json
@@ -5,16 +5,16 @@
 			"model": "ZW139-C", //Nano Switch
 			"manufacturerId": "0x0086",
 			"productType": "0x0003", //EU
-			"productId": "0x008b",
+			"productId": "0x008b"
 		}
 	],
-	"upgrades": [ 
+	"upgrades": [
 		//firmware 3.01
 		{
 			"$if": "firmwareVersion >= 1.0 && firmwareVersion < 3.1",
 			"version": "3.1",
 			"channel": "stable",
-			"changelog": "Bug Fixes:\n* (V2.00) External Switch Auto Detection.\n* Switch state report speed.\n* Better WallSwipe IR Filtering.\n* Improved NVM Reliability.\n* If updating from V2.XX or earlier, it may factory reset the Nano Switch and will require re-pairing.",
+			"changelog": "Note: If updating from V2.XX or earlier, the Nano Switch may be reset to factory settings and require re-pairing.\n\nBug Fixes:\n* (V2.00) External Switch Auto Detection.\n* Switch state report speed.\n* Better WallSwipe IR Filtering.\n* Improved NVM Reliability.",
 			"files": [
 				{
 					"target": 0,


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->