### PR TITLE
Add Zooz ZSE44 firmware version 2.30, for US and EU

### DIFF
--- a/firmwares/zooz/ZSE44-V02.json
+++ b/firmwares/zooz/ZSE44-V02.json
@@ -14,6 +14,20 @@
 	],
 	"upgrades": [
 		{
+			"version": "2.30.0",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30.\n* Fixed temperature reporting edge case: Resolved an issue where the temperature sensor could incorrectly report 32°F (0°C) in certain edge cases (firmware 2.10 and/or 2.20). This was caused by the device requiring additional time to wake from sleep mode, which occasionally resulted in a software read timeout. The new firmware extends the timeout period to ensure accurate data retrieval.",
+			"url": "https://www.getzooz.com/firmware/ZSE44_V02R30_US.gbl",
+			"integrity": "sha256:199dd30a2b01a259ffcaf0ae383a696bbc389b8166082fbfa6a526c54287981c"
+		},
+		{
+			"version": "2.30.0",
+			"region": "europe",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30.\n* Fixed temperature reporting edge case: Resolved an issue where the temperature sensor could incorrectly report 32°F (0°C) in certain edge cases (firmware 2.10 and/or 2.20). This was caused by the device requiring additional time to wake from sleep mode, which occasionally resulted in a software read timeout. The new firmware extends the timeout period to ensure accurate data retrieval.",
+			"url": "https://www.getzooz.com/firmware/ZSE44_V02R30_EU.gbl",
+			"integrity": "sha256:b6c567d5d28ee889278db4a30765bb3236954f3e5366969ad4827fb6eef6228b"
+		},
+		{
 			"version": "2.20.1",
 			"region": "usa",
 			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20.\n* Updated temperature report: When the device cannot retrieve the correct temperature reading, it will now send the last valid value instead of defaulting to 32°F.\n* Updated power calculation algorithm to optimize battery reports.",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->