### PR TITLE
Add Aeotec Heavy Duty Smart Switch Firmware v3.28

### DIFF
--- a/firmwares/aeotec/ZW078-A.json
+++ b/firmwares/aeotec/ZW078-A.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW078-A", //Heavy Duty Smart Switch
+			"manufacturerId": "0x0086",
+			"productType": "0x0103", //US
+			"productId": "0x004e"
+		}
+	],
+	"upgrades": [ 
+		//firmware V3.28
+		{
+			"$if": "firmwareVersion >= 3.25 && firmwareVersion < 3.28",
+			"version": "3.28",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Minor logic refinement for kWh calculation\n* Threshold Parameter fix",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://github.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/raw/refs/heads/main/Series_500/ZW078_HDSSGen5_US_V3_28.exe",
+					"integrity": "sha256:e5592b03948cc96a4c5486cde1e02ea7f7116e7553d097be1c6c902efeb328b5"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/aeotec/ZW078-C.json
+++ b/firmwares/aeotec/ZW078-C.json
@@ -1,0 +1,27 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZW078-C", //Heavy Duty Smart Switch
+			"manufacturerId": "0x0086",
+			"productType": "0x0003", //EU
+			"productId": "0x004e"
+		}
+	],
+	"upgrades": [ 
+		//firmware V3.28
+		{
+			"$if": "firmwareVersion >= 3.25 && firmwareVersion < 3.28",
+			"version": "3.28",
+			"channel": "stable",
+			"changelog": "Bug Fixes:\n* Minor logic refinement for kWh calculation\n* Threshold Parameter fix",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://github.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/raw/refs/heads/main/Series_500/ZW078_HDSSGen5_EU_V3_28.exe",
+					"integrity": "sha256:c1897b0a6e1621721ae33c7d2d0c2c8d1f1922af0b7ee93547df003bd1adb2ab"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
.otz and .hex do not have EOL added, using .EXE files instead.

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->