### PR TITLE
Add Aeotec SmokeShield Firmware v1.00

### DIFF
--- a/firmwares/aeotec/ZWA050.json
+++ b/firmwares/aeotec/ZWA050.json
@@ -14,7 +14,7 @@
 			"$if": "firmwareVersion < 1.0",
 			"version": "1.0",
 			"channel": "stable",
-			"changelog": "Stable update - first release.",
+			"changelog": "Initial release",
 			"files": [
 				{
 					"target": 0,


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->