### PR TITLE
Add Aeotec ZWA010 (Z-Stick 7), FW 7.18.8 and 7.21.7

### DIFF
--- a/firmwares/aeotec/ZWA010ZStick7.json
+++ b/firmwares/aeotec/ZWA010ZStick7.json
@@ -1,0 +1,58 @@
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZWA010", //Z-Stick7 Z-Wave
+			"manufacturerId": "0x0371",
+			"productType": "0x0004",
+			"productId": "0x0004",
+			"firmwareVersion": {
+				"min": "2.11",
+				"max": "2.18"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "2.18.8",
+			"channel": "stable",
+			"changelog": "Update ZWave SDK to 2.18.8 used in controller",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://github.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/raw/refs/heads/main/Series_700/zwave_ncp_serial_api_controller_BRD4206A_7_18_8.gbl",
+					"integrity": "sha256:4956129655347aecd93198a1ca227136b50d6aefb75e496d1b0aab67f32e870d"
+				}
+			]
+		}
+	]
+},
+{
+	"devices": [
+		{
+			"brand": "Aeotec",
+			"model": "ZWA010", //Z-Stick7 Z-Wave
+			"manufacturerId": "0x0371",
+			"productType": "0x0004",
+			"productId": "0x0004",
+			"firmwareVersion": {
+				"min": "2.18",
+				"max": "2.21"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "2.21.7",
+			"channel": "stable",
+			"changelog": "Update ZWave SDK to 2.18.8 used in controller",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://github.com/Aeotec-ccheng/aeotecZWaveOtaUpdateFiles/raw/refs/heads/main/Series_700/zwave_ncp_serial_api_controller_BRD4206A_7_21_7.gbl",
+					"integrity": "sha256:7092353ee2a71be98d6aa00ac36c1f1fb99c5fed5249db245d0e9fc92704d175"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
2 separate updates added:
Z-Stick 7 Update (If V2.11.X to V2.17.X detected) to V7.18.8 Z-Stick 7 Update (If V2.18.X to V2.21.X detected) to V7.21.7

@AlCalzone i was thinking about this one for awhile, i realized that all Series 700 sticks may have the same identifiers compared to the Series 800.

So if i were to push a firmware update for the Z-Stick 7, this would also apply to any Series 700 USB Adapter as they would utilize the same manufacturerID (0x0000), productType (0x0004), and productID (0x0004). I'm not sure if this would cause any issues with any other manufacturers so we may need to get approval from other Series 700 controller manufacturers?

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->