### PR TITLE
Add Zooz ZEN58, firmware version 1.20, US

### DIFF
--- a/firmwares/zooz/ZEN58-V01.json
+++ b/firmwares/zooz/ZEN58-V01.json
@@ -18,7 +18,7 @@
 			"region": "usa",
 			"changelog": "Includes firmware versions: 1.0, 1.10, 1.20.\n* Updated SDK from 7.18.8 to 7.24.1",
 			"url": "https://www.getzooz.com/firmware/ZEN58_V01R20_US.gbl",
-			"integrity": "ha256:361c34f20b57ce41e268d34fa040da9993ccd4c3aabc732a7aa020f72acb56d1"
+			"integrity": "sha256:361c34f20b57ce41e268d34fa040da9993ccd4c3aabc732a7aa020f72acb56d1"
 		}
 	]
 }


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->