### PR TITLE
Promote ZWA-2 FW 1.2.0 to stable, disallow downgrades

### DIFF
--- a/firmwares/nabu_casa/ZWA-2.json
+++ b/firmwares/nabu_casa/ZWA-2.json
@@ -14,13 +14,15 @@
 	],
 	"upgrades": [
 		{
+			"$if": "firmwareVersion < 1.2.0",
 			"version": "1.2.0",
-			"channel": "beta",
+			"channel": "stable",
 			"changelog": "The SDK was updated to Simplicity SDK 2025.12.1, which includes the following fixes, among others:\n* Fixed an issue where the radio layer would stop receiving packet until the next TX radio event\n* Fixed an issue in the Z-Wave LR TX power algorithm causing incorrect transmit powers\n* Fixed an issue where priority routes without repeaters could not be configured",
 			"url": "https://github.com/NabuCasa/zwave-firmware/releases/download/1.2.0/zwa2_controller_1.2.0.gbl",
 			"integrity": "sha256:83cbb9de021ade0a2e75674fdefaccd8b348d72a2845d6bf3cf696f8376f2d3e"
 		},
 		{
+			"$if": "firmwareVersion < 1.1.0",
 			"version": "1.1.0",
 			"channel": "stable",
 			"changelog": "* Correct default powerlevels for EU region\n* Remove RGB and dimming functionality from the LED, convert to cold-white on/off light\n* Change tilt indication to fast blinking",
@@ -28,6 +30,7 @@
 			"integrity": "sha256:5efbfdc621cffb20bbbc400fa3b10f00fc8d53048e8d867c707e4f8174778a2c"
 		},
 		{
+			"$if": "firmwareVersion < 1.0.0",
 			"version": "1.0.0",
 			"channel": "stable",
 			"changelog": "* Initial version",


### PR DESCRIPTION
Testing was successful so far, so we can promote this version to stable.