### PR TITLE
fix: remove leading zeros in padVersion to ensure semver compatibility

### DIFF
--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -46,8 +46,10 @@ export function formatId(id: number | string): string {
 
 /** Pads a firmware version string, so it can be compared with semver */
 export function padVersion(version: string, suffix: string = "0"): string {
-	if (version.split(".").length === 3) return version;
-	return version + `.${suffix}`;
+    const parts = version.split(".").map(p => String(parseInt(p, 10)));
+    if (parts.length === 3) return parts.join(".");
+    if (parts.length === 2) return parts.join(".") + `.${suffix}`;
+    return parts.join(".") + `.0.${suffix}`;
 }
 
 export function compareVersions(v1: string, v2: string): -1 | 0 | 1 {


### PR DESCRIPTION
Fixes #283

## Problem

Firmware version strings like `2.00` were padded to `2.00.0`, which is invalid semver due to leading zeros in numeric identifiers. This caused `semver.gte()` / `semver.lt()` to throw a `TypeError`, which was silently caught by `tryOr()` returning `false`.

As a result, conditions like `firmwareVersion >= 2.00 && firmwareVersion < 2.21` always evaluated to `false`, causing the firmware update service to return an empty `updates` array for affected devices — even when a matching entry existed in the repository.

## Root Cause

`padVersion("2.00")` returned `"2.00.0"` — semver does not allow leading zeros in version components.

## Fix

Parse each version component as an integer before joining, stripping leading zeros:
- `"2.00"` → `"2.0.0"` ✅
- `"2.16"` → `"2.16.0"` ✅ (unchanged)
- `"2.16.0"` → `"2.16.0"` ✅ (unchanged)

## Testing

Verified locally using the dev server with the ZWA005-C EU device (firmware `2.16`, condition `firmwareVersion >= 2.00 && firmwareVersion < 2.21`) — update to `2.21` is now correctly returned.