### PR TITLE
Add Philio to known manufacturer accounts

### DIFF
--- a/.github/scripts/definitions.js
+++ b/.github/scripts/definitions.js
@@ -7,6 +7,7 @@ const manufacturerAccounts = [
 	"InovellilUSA", // Inovelli
 	"chancehiblinds", // iBlinds
 	"jascoproducts", // Jasco
+	"philiotech", // Philio
 ];
 
 module.exports = {


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->