### PR TITLE
Add Zooz ZEN72-V04-800-LR, US, firmware 4.20

### DIFF
--- a/firmwares/zooz/ZEN72-V04-800-LR.json
+++ b/firmwares/zooz/ZEN72-V04-800-LR.json
@@ -1,0 +1,24 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZEN72",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xa002",
+			"firmwareVersion": {
+				"min": "4.0",
+				"max": "4.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "4.20.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 4.0, 4.10, 4.20.\n* Updated SDK from 7.19.3 to 7.24.1.",
+			"url": "https://www.getzooz.com/firmware/ZEN72_V04R20.gbl",
+			"integrity": "sha256:f63828ce7a388c4dbd8b17c70d0e23a8d8dd569f5bac3e316fb6d752b7e4f058"
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->