### PR TITLE
Add Zooz ZEN75-V01-800-LR, US, firmware 1.30

### DIFF
--- a/firmwares/zooz/ZEN75-V01-800-LR.json
+++ b/firmwares/zooz/ZEN75-V01-800-LR.json
@@ -14,6 +14,13 @@
 	],
 	"upgrades": [
 		{
+			"version": "1.30.0",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 1.00, 1.10, 1.20, 1.30.\n* Updated SDK from 7.19.3 to 7.24.1.",
+			"url": "https://www.getzooz.com/firmware/ZEN75_V01R30.gbl",
+			"integrity": "sha256:e9198ef7f00fcdd40c646d01bf34e8fe07b2f404393a94b176d8f22d3985c3e8"
+		},
+		{
 			"version": "1.20.0",
 			"region": "usa",
 			"changelog": "* Includes firmware versions: 1.00, 1.10, 1.20.\n* Added new parameters: 20 - Scene Control Multi-Tap, 21 - LED Indicator Multi-Color.",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->