### PR TITLE
Add Zooz ZEN77-V05-800-LR, US, firmware 5.10

### DIFF
--- a/firmwares/zooz/ZEN77-V05-800-LR.json
+++ b/firmwares/zooz/ZEN77-V05-800-LR.json
@@ -1,0 +1,24 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZEN77",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xa007",
+			"firmwareVersion": {
+				"min": "5.0",
+				"max": "5.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "5.10.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 5.00, 5.10.\n* Updated SDK from 7.19.3 to 7.24.1.",
+			"url": "https://www.getzooz.com/firmware/ZEN77_V05R10.gbl",
+			"integrity": "sha256:0e7bb0c051c0498aa3848ee747be60816792f2c20649255b374bb0742a114b13"
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->