### PR TITLE
Add Zooz ZEN05-V02-800-LR, US, firmware 2.30

### DIFF
--- a/firmwares/zooz/ZEN05-V02-800-LR.json
+++ b/firmwares/zooz/ZEN05-V02-800-LR.json
@@ -14,9 +14,16 @@
 	],
 	"upgrades": [
 		{
+			"version": "2.30.0",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30.\n* Updated SDK from 7.19.3 to 7.24.1.",
+			"url": "https://www.getzooz.com/firmware/ZEN05_V02R30.gbl",
+			"integrity": "sha256:1dbc8cb95ce046fede62a22021c4cffb2a171070ea9133640e81b201f9e3a9ce"
+		},
+		{
 			"version": "2.20.1",
 			"region": "usa",
-			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20\n* Optimized Z-Wave reporting behavior: when Basic Set or Binary Set commands are sent from the Z-Wave controller (Lifeline), the device will no longer send redundant report or notification commands back to the controller.\n* Adjusted the over-voltage protection threshold in the firmware from 135VAC to 150VAC to minimize false triggers in specific scenarios.",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20.\n* Optimized Z-Wave reporting behavior: when Basic Set or Binary Set commands are sent from the Z-Wave controller (Lifeline), the device will no longer send redundant report or notification commands back to the controller.\n* Adjusted the over-voltage protection threshold in the firmware from 135VAC to 150VAC to minimize false triggers in specific scenarios.",
 			"url": "https://www.getzooz.com/firmware/ZEN05_V02R20.gbl",
 			"integrity": "sha256:07df6ec8dbd73d30034007d469a1a3bd69aebb5caa35098e135a99220ac93c1e"
 		}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->