### PR TITLE
Add Zooz ZSE42-V02, US and EU, firmware 2.40

### DIFF
--- a/firmwares/zooz/ZSE42-V02.json
+++ b/firmwares/zooz/ZSE42-V02.json
@@ -14,30 +14,44 @@
 	],
 	"upgrades": [
 		{
+			"version": "2.40.0",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30, 2.40.\n* Updated SDK from 7.19.3 to 7.24.1.",
+			"url": "https://www.getzooz.com/firmware/ZSE42_V02R40_US.gbl",
+			"integrity": "sha256:ac73e348f045b7239a5ff15ef1216b6617d0df0a3370513a68ffe0e2b7754b88"
+		},
+		{
+			"version": "2.40.0",
+			"region": "europe",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30, 2.40.\n* Updated SDK from 7.19.3 to 7.24.1.\n* Added Long Range support for Europe.",
+			"url": "https://www.getzooz.com/firmware/ZSE42_V02R40_EU.gbl",
+			"integrity": "sha256:416879921691121d1775ab975f72f6fa1efba0b042bfb505febc7f4ace420b25"
+		},
+		{
 			"version": "2.30.0",
 			"region": "usa",
-			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30\n* Corrected the behavior of parameter 5 for Basic Set Commands with Value 3 - Absence of water, send Basic Set for On, and Value 4 - Presence of water, send Basic Set for Off.",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30.\n* Corrected the behavior of parameter 5 for Basic Set Commands with Value 3 - Absence of water, send Basic Set for On, and Value 4 - Presence of water, send Basic Set for Off.",
 			"url": "https://www.getzooz.com/firmware/ZSE42_V02R30_US.gbl",
 			"integrity": "sha256:1639d3d43c7089dfb1f0bbc42091349abf4c073fbe4c80d6fe362abac9bb586c"
 		},
 		{
 			"version": "2.30.0",
 			"region": "europe",
-			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30\n* Corrected the behavior of parameter 5 for Basic Set Commands with Value 3 - Absence of water, send Basic Set for On, and Value 4 - Presence of water, send Basic Set for Off.",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30.\n* Corrected the behavior of parameter 5 for Basic Set Commands with Value 3 - Absence of water, send Basic Set for On, and Value 4 - Presence of water, send Basic Set for Off.",
 			"url": "https://www.getzooz.com/firmware/ZSE42_V02R30_EU.gbl",
 			"integrity": "sha256:98b241d916fd5479574df10825d7d4e2d8b417d214e06469a3591c6bddb6fb73"
 		},
 		{
 			"version": "2.20.0",
 			"region": "usa",
-			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20\n* Updated parameter 5 for Basic Set Commands with Value 3 - Basic Set for On and Value 4 - Basic Set for Off.",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20.\n* Updated parameter 5 for Basic Set Commands with Value 3 - Basic Set for On and Value 4 - Basic Set for Off.",
 			"url": "https://www.getzooz.com/firmware/ZSE42_V02R20_US.gbl",
 			"integrity": "sha256:4c6b24c934057fb91977589c504915276fbf773c3ab69cc136592ab3f4a4aefe"
 		},
 		{
 			"version": "2.20.0",
 			"region": "europe",
-			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20\n* Updated parameter 5 for Basic Set Commands with Value 3 - Basic Set for On and Value 4 - Basic Set for Off.",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20.\n* Updated parameter 5 for Basic Set Commands with Value 3 - Basic Set for On and Value 4 - Basic Set for Off.",
 			"url": "https://www.getzooz.com/firmware/ZSE42_V02R20_EU.gbl",
 			"integrity": "sha256:d3ab95e9114c191ef081bbe133513bda35ce1e2130f867db940b04d301c188df"
 		}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->