### PR TITLE
Add Zooz ZSE70-V01-800-LR, US and EU, firmware 1.30.1

### DIFF
--- a/firmwares/zooz/ZSE70-V01-800-LR.json
+++ b/firmwares/zooz/ZSE70-V01-800-LR.json
@@ -1,0 +1,31 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZSE70",
+			"manufacturerId": "0x027a",
+			"productType": "0x0004",
+			"productId": "0x0006",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "1.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.30.1",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 1.0, 1.20, 1.30.\n* Fixed a bug that caused the sensor to report negative lux values under certain conditions on specific platforms.\n* Fixed a bug where setting parameter 16 to any value other than the default prevented the LED indicator from flashing on motion.\n* Updated parameter names and short descriptions in the Configuration Command Class for improved clarity and consistency.\n* Updated SDK from 7.19.3 to 7.24.2.",
+			"url": "https://www.getzooz.com/firmware/ZSE70_V01R30_US.gbl",
+			"integrity": "sha256:f91485e6ea91d3a43ec9040fe7e7f3bab0f42fc8c419e2023c7c861a523d1f2d"
+		},
+		{
+			"version": "1.30.1",
+			"region": "europe",
+			"changelog": "* Includes firmware versions: 1.0, 1.20, 1.30.\n* Fixed a bug that caused the sensor to report negative lux values under certain conditions on specific platforms.\n* Fixed a bug where setting parameter 16 to any value other than the default prevented the LED indicator from flashing on motion.\n* Updated parameter names and short descriptions in the Configuration Command Class for improved clarity and consistency.\n* Updated SDK from 7.19.3 to 7.24.2.\n* Added Long Range support for Europe.",
+			"url": "https://www.getzooz.com/firmware/ZSE70_V01R30_EU.gbl",
+			"integrity": "sha256:c2256ad4c0ec6277fa33e9c07bed3f94a5125cab5504ffe01b3f36498cdd0729"
+		}
+	]
+}0

--- a/firmwares/zooz/ZSE70-V01-800-LR.json
+++ b/firmwares/zooz/ZSE70-V01-800-LR.json
@@ -28,4 +28,4 @@
 			"integrity": "sha256:c2256ad4c0ec6277fa33e9c07bed3f94a5125cab5504ffe01b3f36498cdd0729"
 		}
 	]
-}0
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->