### PR TITLE
Add Zooz ZEN78-V01, US, firmware 1.20

### DIFF
--- a/firmwares/zooz/ZEN78-V01.json
+++ b/firmwares/zooz/ZEN78-V01.json
@@ -16,7 +16,7 @@
 		{
 			"version": "1.20.0",
 			"region": "usa",
-			"changelog": "Includes firmware versions: 1.10, 1.20.\n *Fixed a bug where a ZEN78 powered on outside the Z-Wave network and later added would fail to start scheduled kWh reporting correctly. Now, the device reports kWh properly regardless of when it is added to the network and follows parameter 6 settings as expected.",
+			"changelog": "Includes firmware versions: 1.10, 1.20.\n* Fixed a bug where a ZEN78 powered on outside the Z-Wave network and later added would fail to start scheduled kWh reporting correctly. Now, the device reports kWh properly regardless of when it is added to the network and follows parameter 6 settings as expected.",
 			"url": "https://www.getzooz.com/firmware/ZEN78_V01R20.gbl",
 			"integrity": "sha256:5f9f9d79ac74efcb949c6011ee8d219c5dc4f2da521a75004125f8cd80deec32"
 		}

--- a/firmwares/zooz/ZEN78-V01.json
+++ b/firmwares/zooz/ZEN78-V01.json
@@ -1,0 +1,24 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZEN78",
+			"manufacturerId": "0x027a",
+			"productType": "0x0103",
+			"productId": "0x004e",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "1.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.20.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 1.10, 1.20.\n *Fixed a bug where a ZEN78 powered on outside the Z-Wave network and later added would fail to start scheduled kWh reporting correctly. Now, the device reports kWh properly regardless of when it is added to the network and follows parameter 6 settings as expected.",
+			"url": "https://www.getzooz.com/firmware/ZEN78_V01R20.gbl",
+			"integrity": "sha256:5f9f9d79ac74efcb949c6011ee8d219c5dc4f2da521a75004125f8cd80deec32"
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->