### PR TITLE
Add Zooz ZST39-V01, US and EU, firmware 1.70

### DIFF
--- a/firmwares/zooz/ZST39-V01.json
+++ b/firmwares/zooz/ZST39-V01.json
@@ -1,0 +1,31 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZST39",
+			"manufacturerId": "0x027a",
+			"productType": "0x0004",
+			"productId": "0x0610",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "1.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.70.0",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 1.10, 1.20, 1.30, 1.40, 1.50, 1.60, 1.70\n* Based on Z-Wave SDK version 7.24.2.",
+			"url": "https://www.getzooz.com/firmware/ZST39_SDK_7.24.2_US-LR_V01R70.gbl",
+			"integrity": "sha256:b37aa49d7a91752505e4b9685cab84a279e0f61bd286518c8e24fb74e88531be"
+		},
+		{
+			"version": "1.70.0",
+			"region": "europe",
+			"changelog": "* Includes firmware versions: 1.10, 1.20, 1.30, 1.40, 1.50, 1.60, 1.70\n* Based on Z-Wave SDK version 7.24.2.",
+			"url": "https://www.getzooz.com/firmware/ZST39_SDK_7.24.2_EU-LR_V01R70.gbl",
+			"integrity": "sha256:426f5e7274df0af59ddd1d95f39bc16780e3d020db6856802270b4e892c3a94a"
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->