### PR TITLE
Add Zooz ZEN76-V04-800-LR, US, firmware 4.10

### DIFF
--- a/firmwares/zooz/ZEN76-V04-800-LR.json
+++ b/firmwares/zooz/ZEN76-V04-800-LR.json
@@ -1,0 +1,24 @@
+{
+	"devices": [
+		{
+			"brand": "Zooz",
+			"model": "ZEN76",
+			"manufacturerId": "0x027a",
+			"productType": "0x7000",
+			"productId": "0xa006",
+			"firmwareVersion": {
+				"min": "4.0",
+				"max": "4.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "4.10.0",
+			"region": "usa",
+			"changelog": "Includes firmware versions: 4.0, 4.10.\n* Updated SDK from 7.19.3 to 7.24.1.",
+			"url": "https://www.getzooz.com/firmware/ZEN76_V04R10.gbl",
+			"integrity": "sha256:ec5a0e6d8463ccddb9a057a5013e2821277a2e78ac3065c8ad25c50947081675"
+		}
+	]
+}


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->