### PR TITLE
Add Shelly Wave Plug S, Plug US, i4, i4 DC, 1PM, Pro Shutter, Pro 1PM, Pro 1, Pro 2PM firmware updates

### DIFF
--- a/firmwares/shelly/qnpl-001X16US.json
+++ b/firmwares/shelly/qnpl-001X16US.json
@@ -14,6 +14,17 @@
 	],
 	"upgrades": [
 		{
+			"version": "13.0",
+			"changelog": "- SDK with fixed dead node issue",
+			"region": "usa",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Plug_US/US/Wave_PlugUS_800_US_LR_20250204_1000_QNPL-001X16US_%5B13.00%5D_9DD2F96C.gbl",
+					"integrity": "sha256:608a54b1d9e1a2747411a28a4ed25cc9ff73f3492fa9c2ec73a1fa51d47f02a3"
+				}
+			]
+		},
+		{
 			"version": "10.11",
 			"changelog": "- optimised temperature conversion table\n- Meter Reset Command fixed\n- other minor improvements",
 			"region": "usa",

--- a/firmwares/shelly/qnpl-0A112EU.json
+++ b/firmwares/shelly/qnpl-0A112EU.json
@@ -14,6 +14,17 @@
 	],
 	"upgrades": [
 		{
+			"version": "12.2",
+			"changelog": "- SDK with fixed dead node issue\n- fixed AC disconnect alarm functionality\n- improved Zero Crossing detection",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/7f92ad9cde6240d0d66eae213f81d38e7096ceff/Wave_Plug_S/EU/Wave_PlugS_800_EU_LR_20260205_1034_QLPL-0A112EU_%5B12.02%5D_0FE4B35C.gbl",
+					"integrity": "sha256:d6ff2545198f52f075d3024bebd7ce56d212dc65551eac874233eaf9503580a8"
+				}
+			]
+		},
+		{
 			"version": "11.4",
 			"changelog": "- Added kWh precision 2 decimals\n- Added min value for Par 105 -> 0 - off\n- Added Indicator Command Class\n- Removed Parameters 91 - 94\n- Removed Association group 3\n- Removed voltage & ampere reports\n- Other minor Fixes & Improvements",
 			"region": "europe",

--- a/firmwares/shelly/qnsn-0A24x.json
+++ b/firmwares/shelly/qnsn-0A24x.json
@@ -38,7 +38,7 @@
 		{
 			"version": "13.1",
 			"changelog": "- SDK with fixed dead node issue\n- Fixed Association\n- Fixed Part number\n- Fixed Indicator CC support\n- Fixed short press for Central Scene manager (200ms -> 500ms)\n- Fixed Binary Switch now reports state at boot up\n- Fixed Parameters 1 - 4 to properly handle value 1\n- Added Parameter 118 (switch exclusion enable/disable)\n- Added Parameter 117 - Reboot device\n- Added Support for EU LR\n- Changed Association handling into a more modern, safe, implementation\n- Other minor fixes and improvements",
-			"region": "USA",
+			"region": "usa",
 			"files": [
 				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/68354455ae3912c7dafa269c8793bc6dd34ebe65/Wave_i4/US/Wave_i4_800_US_LR_20260312_1043_QLSN-0A24XUS_%5Bv13.01%5D_EB201890.gbl",

--- a/firmwares/shelly/qnsn-0A24x.json
+++ b/firmwares/shelly/qnsn-0A24x.json
@@ -14,6 +14,39 @@
 	],
 	"upgrades": [
 		{
+			"version": "13.1",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Association\n- Fixed Part number\n- Fixed Indicator CC support\n- Fixed short press for Central Scene manager (200ms -> 500ms)\n- Fixed Binary Switch now reports state at boot up\n- Fixed Parameters 1 - 4 to properly handle value 1\n- Added Parameter 118 (switch exclusion enable/disable)\n- Added Parameter 117 - Reboot device\n- Added Support for EU LR\n- Changed Association handling into a more modern, safe, implementation\n- Other minor fixes and improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/68354455ae3912c7dafa269c8793bc6dd34ebe65/Wave_i4/ANZ/Wave_i4_800_ANZ_20260312_1043_QNSN-0A24XAU_%5Bv13.01%5D_0FE4B35C.gbl",
+					"integrity": "sha256:207fda76e7f4286a767dece948869d412cbdc5a0c365e014c5813ef11547718b"
+				}
+			]
+		},
+		{
+			"version": "13.1",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Association\n- Fixed Part number\n- Fixed Indicator CC support\n- Fixed short press for Central Scene manager (200ms -> 500ms)\n- Fixed Binary Switch now reports state at boot up\n- Fixed Parameters 1 - 4 to properly handle value 1\n- Added Parameter 118 (switch exclusion enable/disable)\n- Added Parameter 117 - Reboot device\n- Added Support for EU LR\n- Changed Association handling into a more modern, safe, implementation\n- Other minor fixes and improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/68354455ae3912c7dafa269c8793bc6dd34ebe65/Wave_i4/EU/Wave_i4_800_EU_LR_20260312_1043_QLSN-0A24XEU_%5Bv13.01%5D_EB201890.gbl",
+					"integrity": "sha256:5c8e8347b243bfb536738fae467457428e38f97de09d75860670ba3201f80f7a"
+				}
+			]
+		},
+		{
+			"version": "13.1",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Association\n- Fixed Part number\n- Fixed Indicator CC support\n- Fixed short press for Central Scene manager (200ms -> 500ms)\n- Fixed Binary Switch now reports state at boot up\n- Fixed Parameters 1 - 4 to properly handle value 1\n- Added Parameter 118 (switch exclusion enable/disable)\n- Added Parameter 117 - Reboot device\n- Added Support for EU LR\n- Changed Association handling into a more modern, safe, implementation\n- Other minor fixes and improvements",
+			"region": "USA",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/68354455ae3912c7dafa269c8793bc6dd34ebe65/Wave_i4/US/Wave_i4_800_US_LR_20260312_1043_QLSN-0A24XUS_%5Bv13.01%5D_EB201890.gbl",
+					"integrity": "sha256:86c2a0f3588e2f735442262f0c0e92cb04171d54afb5f92df3405164f2214d79"
+				}
+			]
+		},
+		{
 			"version": "11.5",
 			"changelog": "- Binary switch report at boot up\n- Parameters 1 - 4 value 1 fixed\n- optimised temperature conversion table",
 			"region": "europe",

--- a/firmwares/shelly/qnsn-0D24x.json
+++ b/firmwares/shelly/qnsn-0D24x.json
@@ -1,35 +1,61 @@
 {
-	"devices": [
-		{
-			"brand": "Shelly Qubino",
-			"model": "Wave i4 DC",
-			"manufacturerId": "0x0460",
-			"productType": "0x0009",
-			"productId": "0x0082",
-			"firmwareVersion": {
-				"min": "0.0",
-				"max": "255.255"
-			}
-		}
-	],
-	"upgrades": [
-		{
-			"version": "11.5",
-			"changelog": "- Binary switch report at boot up\n- Parameters 1 - 4 value 1 fixed",
-			"region": "europe",
-			"files": [
-				{
-					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/d3c93f6c456ab635e40b1c03197060ccb1fcd8ba/Wave_i4_DC/EU/Wave_i4_DC_800_EU_20240523_1558_QNSN-0D24XEU_%5B11.05%5D_9DD2F96C%20(1).gbl",
-					"integrity": "sha256:7376ef6f758e89b68b04d5d6713407eb4bd3e9d6c8b33db6f8b67c7bea37dd92"
-				}
-			]
-		},
-		{
-			"version": "13.0",
-			"changelog": "- Fixed Association\n- Fixed Part number\n- Fixed Indicator CC support\n- Fixed short press for Central Scene manager (200ms -> 500ms)\n- Fixed Binary Switch now reports state at boot up\n- Fixed Parameters 1 - 4 to properly handle value\n- Added Parameter 117 - Reboot device\n- Added Support for EU LR\n- Changed Association handling into a more modern, safe, implementation\n- Other minor fixes and improvements",
-			"region": "europe",
-			"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/876e761b570b5f0f331bfaad431e859ebc826522/Wave_i4_DC/EU/Wave_i4_dc_800_EU_LR_20260312_0959_QLSN-0D24XEU_%5Bv13.00_2144DF1C.gbl",
-			"integrity": "sha256:7a05464b78d6a9312aa383c840e33662a9a5e0dcac0c451d8f9874b3b05a54d5"
-		}
-	]
+  "devices": [
+    {
+      "brand": "Shelly Qubino",
+      "model": "Wave i4 DC",
+      "manufacturerId": "0x0460",
+      "productType": "0x0009",
+      "productId": "0x0082",
+      "firmwareVersion": {
+        "min": "0.0",
+        "max": "255.255"
+      }
+    }
+  ],
+  "upgrades": [
+    {
+      "version": "13.0",
+      "changelog": "- SDK with fixed dead node issue\n- Fixed Association\n- Fixed Part number\n- Fixed Indicator CC support\n- Fixed short press for Central Scene manager (200ms -> 500ms)\n- Fixed Binary Switch now reports state at boot up\n- Fixed Parameters 1 - 4 to properly handle value 1\n- Added Parameter 117 - Reboot device\n- Added Support for EU LR\n- Changed Association handling into a more modern, safe, implementation\n- Other minor fixes and improvements",
+      "region": "australia/new zealand",
+      "files": [
+        {
+          "url":"https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_i4_DC/ANZ/Wave_i4_dc_800_ANZ_20260312_1000_QNSN-0D24XAU_%5Bv13.00%5D_2144DF1C.gbl",
+          "integrity":"sha256:ecc63402e1ba5181287a57779152afe347a97ce2c601e9d67eb148a6df613c1b"
+        }
+      ]
+    },
+    {
+      "version": "13.0",
+      "changelog": "- SDK with fixed dead node issue\n- Fixed Association\n- Fixed Part number\n- Fixed Indicator CC support\n- Fixed short press for Central Scene manager (200ms -> 500ms)\n- Fixed Binary Switch now reports state at boot up\n- Fixed Parameters 1 - 4 to properly handle value 1\n- Added Parameter 117 - Reboot device\n- Added Support for EU LR\n- Changed Association handling into a more modern, safe, implementation\n- Other minor fixes and improvements",
+      "region": "europe",
+      "files": [
+        {
+          "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_i4_DC/EU/Wave_i4_dc_800_EU_LR_20260312_0959_QLSN-0D24XEU_%5Bv13.00_2144DF1C.gbl",
+          "integrity": "sha256:7a05464b78d6a9312aa383c840e33662a9a5e0dcac0c451d8f9874b3b05a54d5"
+        }
+      ]
+    },
+    {
+      "version": "13.0",
+      "changelog": "- SDK with fixed dead node issue\n- Fixed Association\n- Fixed Part number\n- Fixed Indicator CC support\n- Fixed short press for Central Scene manager (200ms -> 500ms)\n- Fixed Binary Switch now reports state at boot up\n- Fixed Parameters 1 - 4 to properly handle value 1\n- Added Parameter 117 - Reboot device\n- Added Support for EU LR\n- Changed Association handling into a more modern, safe, implementation\n- Other minor fixes and improvements",
+      "region": "usa",
+      "files": [
+        {
+          "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_i4_DC/US/Wave_i4_dc_800_US_LR_20260312_1000_QLSN-0D24XUS_%5Bv13.00%5D_2144DF1C.gbl",
+          "integrity": "sha256:febafdafe4b5d0d4209f9260499df928da813939d486480e0ab851e0e10cfd0d"
+        }
+      ]
+    },
+    {
+      "version": "11.5",
+      "changelog": "- Binary switch report at boot up\n- Parameters 1 - 4 value 1 fixed",
+      "region": "europe",
+      "files": [
+        {
+          "url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/d3c93f6c456ab635e40b1c03197060ccb1fcd8ba/Wave_i4_DC/EU/Wave_i4_DC_800_EU_20240523_1558_QNSN-0D24XEU_%5B11.05%5D_9DD2F96C%20(1).gbl",
+          "integrity": "sha256:7376ef6f758e89b68b04d5d6713407eb4bd3e9d6c8b33db6f8b67c7bea37dd92"
+        }
+      ]
+    }
+  ]
 }

--- a/firmwares/shelly/qnsw-001P16.json
+++ b/firmwares/shelly/qnsw-001P16.json
@@ -38,7 +38,7 @@
 		{
 			"version": "14.1",
 			"changelog": "- Corrected Overvoltage threshold to 240+15%V",
-			"region": "USA",
+			"region": "usa",
 			"files": [
 				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/68354455ae3912c7dafa269c8793bc6dd34ebe65/Wave_1PM/US/Wave_1PM_800_US_LR_20260311_0819_QLSW-001P15US_%5Bv14.01%5D_0FE4B35C.gbl",

--- a/firmwares/shelly/qnsw-001P16.json
+++ b/firmwares/shelly/qnsw-001P16.json
@@ -14,6 +14,39 @@
 	],
 	"upgrades": [
 		{
+			"version": "14.1",
+			"changelog": "- Corrected Overvoltage threshold to 240+15%V",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/68354455ae3912c7dafa269c8793bc6dd34ebe65/Wave_1PM/ANZ/Wave_1PM_800_ANZ_20260311_0822_QNSW-001P16AU_%5Bv14.01%5D_9DD2F96C.gbl",
+					"integrity": "sha256:961ca16670ee96935adfdfe789a30d245c853692b533c0986824c8ceb4dfe080"
+				}
+			]
+		},
+		{
+			"version": "14.1",
+			"changelog": "- Corrected Overvoltage threshold to 240+15%V",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/68354455ae3912c7dafa269c8793bc6dd34ebe65/Wave_1PM/EU/Wave_1PM_800_EU_LR_20260302_1609_QLSW-001P16EU_%5Bv14.01%5D_EB201890.gbl",
+					"integrity": "sha256:b4c9d1c9b2c03d9fbb977f08c84b79ebf3c46136a125dbd1c51e75f33165ab71"
+				}
+			]
+		},
+		{
+			"version": "14.1",
+			"changelog": "- Corrected Overvoltage threshold to 240+15%V",
+			"region": "USA",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/68354455ae3912c7dafa269c8793bc6dd34ebe65/Wave_1PM/US/Wave_1PM_800_US_LR_20260311_0819_QLSW-001P15US_%5Bv14.01%5D_0FE4B35C.gbl",
+					"integrity": "sha256:f676871f67591b27f2096b5f63929d1eba2f06addcd6e0bdff3b60f75b86d307"
+				}
+			]
+		},
+		{
 			"version": "14.0",
 			"changelog": "- SDK with fixed dead node issue",
 			"region": "europe",

--- a/firmwares/shelly/qpsh-0A1P10.json
+++ b/firmwares/shelly/qpsh-0A1P10.json
@@ -14,6 +14,39 @@
 	],
 	"upgrades": [
 		{
+			"version": "12.3",
+			"changelog": "- SDK with fixed dead node issue\n- Added detached mode\n- Added inclusion option with disabled input parameter\n- Added manual configuration for up/down parameters (functional via physical inputs; not yet via Z-Wave commands)\n- Added parameter state reporting to controller\n- Added Meter CC support to endpoints\n- Fixed associations to resolve Home Assistant issues\n- Fixed LED signaling\n- Fixed circuit protection\n- Fixed Meter OP parameter (disables end switches when set to 10)\n- Fixed Meter CC (no watt reporting when parameter 36 is set to 0)\n- Fixed venetian mode\n- Fixed parameter 39\n- Fixed calibration issue\n- Fixed abnormal output when parameter 85 is set to 0\n- Fixed multilevel report & multilevel switch start/stop behavior\n- other minor improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_Shutter/ANZ/Wave_PRO shutter_800_ANZ_20260401_1343_QPSH-0A1P10AU_%5Bv12.03%5D_2144DF1C.gbl",
+					"integrity": "sha256:9fe1d96159f340000b17de563b80f9c889c23dc746e1333b6ad07a52add87c2d"
+				}
+			]
+		},
+		{
+			"version": "12.3",
+			"changelog": "- SDK with fixed dead node issue\n- Added detached mode\n- Added inclusion option with disabled input parameter\n- Added manual configuration for up/down parameters (functional via physical inputs; not yet via Z-Wave commands)\n- Added parameter state reporting to controller\n- Added Meter CC support to endpoints\n- Fixed associations to resolve Home Assistant issues\n- Fixed LED signaling\n- Fixed circuit protection\n- Fixed Meter OP parameter (disables end switches when set to 10)\n- Fixed Meter CC (no watt reporting when parameter 36 is set to 0)\n- Fixed venetian mode\n- Fixed parameter 39\n- Fixed calibration issue\n- Fixed abnormal output when parameter 85 is set to 0\n- Fixed multilevel report & multilevel switch start/stop behavior\n- other minor improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_Shutter/EU/Wave_PRO shutter_800_EU_LR_20260401_1341_QUSH-0A1P10EU_%5Bv12.03%5D_9DD2F96C.gbl",
+					"integrity": "sha256:05ed5fbfeba2051fff447d97cf6069b11ea4fb16b1a6bdf95f7c851f5486af71"
+				}
+			]
+		},
+		{
+			"version": "12.3",
+			"changelog": "- SDK with fixed dead node issue\n- Added detached mode\n- Added inclusion option with disabled input parameter\n- Added manual configuration for up/down parameters (functional via physical inputs; not yet via Z-Wave commands)\n- Added parameter state reporting to controller\n- Added Meter CC support to endpoints\n- Fixed associations to resolve Home Assistant issues\n- Fixed LED signaling\n- Fixed circuit protection\n- Fixed Meter OP parameter (disables end switches when set to 10)\n- Fixed Meter CC (no watt reporting when parameter 36 is set to 0)\n- Fixed venetian mode\n- Fixed parameter 39\n- Fixed calibration issue\n- Fixed abnormal output when parameter 85 is set to 0\n- Fixed multilevel report & multilevel switch start/stop behavior\n- other minor improvements",
+			"region": "USA",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_Shutter/US/Wave_PRO shutter_800_US_LR_20260401_1342_QUSH-0A1P10US_%5Bv12.03%5D_2144DF1C.gbl",
+					"integrity": "sha256:a80249b2955345d09f6e5e3341ee7a5cbbaa96b5a4398299d02eae7055a397f3"
+				}
+			]
+		},
+		{
 			"version": "10.8",
 			"changelog": "- optimised temperature conversion table\n- fixed Power Up Shutter Position Report\n- fixed unsolicited Power Report\n- OTA in progress signalisation\n- other minor improvements\n- other minor improvements",
 			"region": "europe",

--- a/firmwares/shelly/qpsh-0A1P10.json
+++ b/firmwares/shelly/qpsh-0A1P10.json
@@ -38,7 +38,7 @@
 		{
 			"version": "12.3",
 			"changelog": "- SDK with fixed dead node issue\n- Added detached mode\n- Added inclusion option with disabled input parameter\n- Added manual configuration for up/down parameters (functional via physical inputs; not yet via Z-Wave commands)\n- Added parameter state reporting to controller\n- Added Meter CC support to endpoints\n- Fixed associations to resolve Home Assistant issues\n- Fixed LED signaling\n- Fixed circuit protection\n- Fixed Meter OP parameter (disables end switches when set to 10)\n- Fixed Meter CC (no watt reporting when parameter 36 is set to 0)\n- Fixed venetian mode\n- Fixed parameter 39\n- Fixed calibration issue\n- Fixed abnormal output when parameter 85 is set to 0\n- Fixed multilevel report & multilevel switch start/stop behavior\n- other minor improvements",
-			"region": "USA",
+			"region": "usa",
 			"files": [
 				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_Shutter/US/Wave_PRO shutter_800_US_LR_20260401_1342_QUSH-0A1P10US_%5Bv12.03%5D_2144DF1C.gbl",

--- a/firmwares/shelly/qpsw-0A1P16.json
+++ b/firmwares/shelly/qpsw-0A1P16.json
@@ -38,7 +38,7 @@
 		{
 			"version": "13.2",
 			"changelog": "- SDK with fixed dead node issue\n- Fixed Overvoltage (230V + 15% -> 240V + 15%)\n- Fixed Overcurrent (25.5A -> 16A + 15%)\n- Fixed soft reset from input toggles\n- Fixed sw2 detached mode parameter default -> 1 (active)\n- Removed parameters no. 91, 92, 93, 94\n- Removed Inclusion/exclusion indication (2x ON/OFF output)\n- Changed energy reporting to two decimal points\n- other minor improvements",
-			"region": "USA",
+			"region": "usa",
 			"files": [
 				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_1PM/US/Wave_Pro_1PM_US_LR_20260229_1040_QUSW-0A1P15US_%5Bv13.02%5D_0FE4B35C.gbl",

--- a/firmwares/shelly/qpsw-0A1P16.json
+++ b/firmwares/shelly/qpsw-0A1P16.json
@@ -14,6 +14,39 @@
 	],
 	"upgrades": [
 		{
+			"version": "13.2",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Overvoltage (230V + 15% -> 240V + 15%)\n- Fixed Overcurrent (25.5A -> 16A + 15%)\n- Fixed soft reset from input toggles\n- Fixed sw2 detached mode parameter default -> 1 (active)\n- Removed parameters no. 91, 92, 93, 94\n- Removed Inclusion/exclusion indication (2x ON/OFF output)\n- Changed energy reporting to two decimal points\n- other minor improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_1PM/ANZ/Wave_Pro_1PM_ANZ_20260229_1040_QPSW-0A1P16AU_%5Bv13.02%5D_0FE4B35C.gbl",
+					"integrity": "sha256:dc65eb056519fb27ebb3a4d2a094201a7e1afb19f5754d83d41eabc4ba447b4e"
+				}
+			]
+		},
+		{
+			"version": "13.2",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Overvoltage (230V + 15% -> 240V + 15%)\n- Fixed Overcurrent (25.5A -> 16A + 15%)\n- Fixed soft reset from input toggles\n- Fixed sw2 detached mode parameter default -> 1 (active)\n- Removed parameters no. 91, 92, 93, 94\n- Removed Inclusion/exclusion indication (2x ON/OFF output)\n- Changed energy reporting to two decimal points\n- other minor improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_1PM/EU/Wave_Pro_1PM_EU_LR_20260229_1043_QUSW-0A1P16EU_%5Bv13.02%5D_EB201890.gbl",
+					"integrity": "sha256:14d5af12ddd82da59c477214656a86faad98add6dbe79b269b4389034294ec1c"
+				}
+			]
+		},
+		{
+			"version": "13.2",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Overvoltage (230V + 15% -> 240V + 15%)\n- Fixed Overcurrent (25.5A -> 16A + 15%)\n- Fixed soft reset from input toggles\n- Fixed sw2 detached mode parameter default -> 1 (active)\n- Removed parameters no. 91, 92, 93, 94\n- Removed Inclusion/exclusion indication (2x ON/OFF output)\n- Changed energy reporting to two decimal points\n- other minor improvements",
+			"region": "USA",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_1PM/US/Wave_Pro_1PM_US_LR_20260229_1040_QUSW-0A1P15US_%5Bv13.02%5D_0FE4B35C.gbl",
+					"integrity": "sha256:88e9a42c48e682ecf62a5c99a36f2dd201dea0da13369045d9a37876cf38271b"
+				}
+			]
+		},
+		{
 			"version": "11.3",
 			"changelog": "- minor improvements",
 			"region": "europe",

--- a/firmwares/shelly/qpsw-0A1X16.json
+++ b/firmwares/shelly/qpsw-0A1X16.json
@@ -38,7 +38,7 @@
 		{
 			"version": "13.1",
 			"changelog": "- SDK with fixed dead node issue\n- Fixed soft reset from input toggles\n- Fixed sw2 detached mode parameter default -> 1 (active)\n- Removed parameters 36/39\n- Removed meter cc\n- Removed power notifications\n- Removed parameters no. 91, 92, 93, 94\n- Removed Inclusion/exclusion\" indication (2x ON/OFF output)\n- Changed energy reporting to two decimal points\n- other minor improvements",
-			"region": "USA",
+			"region": "usa",
 			"files": [
 				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_1/US/Wave_Pro_1_US_LR_20260223_1018_QUSW-0A1X16US_%5Bv13.01%5D_2144DF1C (1).gbl",

--- a/firmwares/shelly/qpsw-0A1X16.json
+++ b/firmwares/shelly/qpsw-0A1X16.json
@@ -14,6 +14,39 @@
 	],
 	"upgrades": [
 		{
+			"version": "13.1",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed soft reset from input toggles\n- Fixed sw2 detached mode parameter default -> 1 (active)\n- Removed parameters 36/39\n- Removed meter cc\n- Removed power notifications\n- Removed parameters no. 91, 92, 93, 94\n- Removed Inclusion/exclusion\" indication (2x ON/OFF output)\n- Changed energy reporting to two decimal points\n- other minor improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_1/ANZ/Wave_Pro_1_ANZ_20260223_1020_QPSW-0A1X16AU_%5Bv13.01%5D_9DD2F96C.gbl",
+					"integrity": "sha256:bd5c8d8c2f1c6570f54ae24f2d8cfc96b29408116897abc6f52a5db6637583ab"
+				}
+			]
+		},
+		{
+			"version": "13.1",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed soft reset from input toggles\n- Fixed sw2 detached mode parameter default -> 1 (active)\n- Removed parameters 36/39\n- Removed meter cc\n- Removed power notifications\n- Removed parameters no. 91, 92, 93, 94\n- Removed Inclusion/exclusion\" indication (2x ON/OFF output)\n- Changed energy reporting to two decimal points\n- other minor improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_1/EU/Wave_Pro_1_EU_LR_20260217_1026_QUSW-0A1X16EU_%5Bv13.01%5D_2144DF1C.gbl",
+					"integrity": "sha256:264fe13b5a3ed2eaa598b8043f4842b7fce67d91d603acb408105741b35e7a3a"
+				}
+			]
+		},
+		{
+			"version": "13.1",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed soft reset from input toggles\n- Fixed sw2 detached mode parameter default -> 1 (active)\n- Removed parameters 36/39\n- Removed meter cc\n- Removed power notifications\n- Removed parameters no. 91, 92, 93, 94\n- Removed Inclusion/exclusion\" indication (2x ON/OFF output)\n- Changed energy reporting to two decimal points\n- other minor improvements",
+			"region": "USA",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_1/US/Wave_Pro_1_US_LR_20260223_1018_QUSW-0A1X16US_%5Bv13.01%5D_2144DF1C (1).gbl",
+					"integrity": "sha256:a37eb5ebac2b61f0b5e7d78a914382415296986aed02cf6fee8a84ebd07abecf"
+				}
+			]
+		},
+		{
 			"version": "11.1",
 			"changelog": "- optimised temperature conversion table\n- - other minor improvements",
 			"region": "europe",

--- a/firmwares/shelly/qpsw-0A2P16.json
+++ b/firmwares/shelly/qpsw-0A2P16.json
@@ -26,7 +26,8 @@
 		},
 		{
 			"version": "13.4",
-			"changelog": "- SDK with fixed dead node issue\n- Fixed overcurrent alarm threshold\n- Fixed LED system caused soft reset\n- Fixed reboot parameter returned to 0 after activation\n- Fixed Meter CC on endpoints\n- Fixed respond to Import rate type Meter get command\n- Fixed Binary Switch Reporting in association with Normally Open / Normally Closed(NO/NC)\n- Added Parameter 117 for device rebooting\n- Changed Energy reporting to 2 decimal points\n- Removed AC main disconnected alarm\n- Removed PARs 91, 92, 93, 94\n- Removed Indicator for successful inclusion\n- other minor improvements",			"region": "europe",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed overcurrent alarm threshold\n- Fixed LED system caused soft reset\n- Fixed reboot parameter returned to 0 after activation\n- Fixed Meter CC on endpoints\n- Fixed respond to Import rate type Meter get command\n- Fixed Binary Switch Reporting in association with Normally Open / Normally Closed(NO/NC)\n- Added Parameter 117 for device rebooting\n- Changed Energy reporting to 2 decimal points\n- Removed AC main disconnected alarm\n- Removed PARs 91, 92, 93, 94\n- Removed Indicator for successful inclusion\n- other minor improvements",
+			"region": "europe",
 			"files": [
 				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_2PM/EU/Wave_PRO_2PM_800_EU_LR_20260310_1041_QUSW-0A2P16EU_%5Bv13.04%5D_EB201890.gbl",
@@ -36,7 +37,8 @@
 		},
 		{
 			"version": "13.4",
-			"changelog": "- SDK with fixed dead node issue\n- Fixed overcurrent alarm threshold\n- Fixed LED system caused soft reset\n- Fixed reboot parameter returned to 0 after activation\n- Fixed Meter CC on endpoints\n- Fixed respond to Import rate type Meter get command\n- Fixed Binary Switch Reporting in association with Normally Open / Normally Closed(NO/NC)\n- Added Parameter 117 for device rebooting\n- Changed Energy reporting to 2 decimal points\n- Removed AC main disconnected alarm\n- Removed PARs 91, 92, 93, 94\n- Removed Indicator for successful inclusion\n- other minor improvements",			"region": "USA",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed overcurrent alarm threshold\n- Fixed LED system caused soft reset\n- Fixed reboot parameter returned to 0 after activation\n- Fixed Meter CC on endpoints\n- Fixed respond to Import rate type Meter get command\n- Fixed Binary Switch Reporting in association with Normally Open / Normally Closed(NO/NC)\n- Added Parameter 117 for device rebooting\n- Changed Energy reporting to 2 decimal points\n- Removed AC main disconnected alarm\n- Removed PARs 91, 92, 93, 94\n- Removed Indicator for successful inclusion\n- other minor improvements",
+			"region": "usa",
 			"files": [
 				{
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_2PM/US/Wave_PRO_2PM_800_US_LR_20260310_1324_QUSW-0A2P25US_%5Bv13.04%5D_2144DF1C.gbl",

--- a/firmwares/shelly/qpsw-0A2P16.json
+++ b/firmwares/shelly/qpsw-0A2P16.json
@@ -14,6 +14,37 @@
 	],
 	"upgrades": [
 		{
+			"version": "13.4",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed overcurrent alarm threshold\n- Fixed LED system caused soft reset\n- Fixed reboot parameter returned to 0 after activation\n- Fixed Meter CC on endpoints\n- Fixed respond to Import rate type Meter get command\n- Fixed Binary Switch Reporting in association with Normally Open / Normally Closed(NO/NC)\n- Added Parameter 117 for device rebooting\n- Changed Energy reporting to 2 decimal points\n- Removed AC main disconnected alarm\n- Removed PARs 91, 92, 93, 94\n- Removed Indicator for successful inclusion\n- other minor improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_2PM/ANZ/Wave_PRO_2PM_800_ANZ_20260310_1323_QPSW-0A2P16AU_%5Bv13.04%5D_0FE4B35C.gbl",
+					"integrity": "sha256:1c611c0d9d2dd07f23d63ce706332e7aa7d208d5818503bdd7e2363937aad2eb"
+				}
+			]
+		},
+		{
+			"version": "13.4",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed overcurrent alarm threshold\n- Fixed LED system caused soft reset\n- Fixed reboot parameter returned to 0 after activation\n- Fixed Meter CC on endpoints\n- Fixed respond to Import rate type Meter get command\n- Fixed Binary Switch Reporting in association with Normally Open / Normally Closed(NO/NC)\n- Added Parameter 117 for device rebooting\n- Changed Energy reporting to 2 decimal points\n- Removed AC main disconnected alarm\n- Removed PARs 91, 92, 93, 94\n- Removed Indicator for successful inclusion\n- other minor improvements",			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_2PM/EU/Wave_PRO_2PM_800_EU_LR_20260310_1041_QUSW-0A2P16EU_%5Bv13.04%5D_EB201890.gbl",
+					"integrity": "sha256:db5aa0beecf43d8bc5218afca2516876a5e9f5a40e78747dc3fa97e858621dd7"
+				}
+			]
+		},
+		{
+			"version": "13.4",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed overcurrent alarm threshold\n- Fixed LED system caused soft reset\n- Fixed reboot parameter returned to 0 after activation\n- Fixed Meter CC on endpoints\n- Fixed respond to Import rate type Meter get command\n- Fixed Binary Switch Reporting in association with Normally Open / Normally Closed(NO/NC)\n- Added Parameter 117 for device rebooting\n- Changed Energy reporting to 2 decimal points\n- Removed AC main disconnected alarm\n- Removed PARs 91, 92, 93, 94\n- Removed Indicator for successful inclusion\n- other minor improvements",			"region": "USA",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Pro_2PM/US/Wave_PRO_2PM_800_US_LR_20260310_1324_QUSW-0A2P25US_%5Bv13.04%5D_2144DF1C.gbl",
+					"integrity": "sha256:38bb1c35dafa1054568b42134c7ba89795e85396f5d252b19339b5401bc0b1a6"
+				}
+			]
+		},
+		{
 			"version": "10.8",
 			"changelog": "- optimised temperature conversion table\n- other minor improvements",
 			"region": "europe",


### PR DESCRIPTION
…, Wave Pro Shutter, Wave Pro 1, Wave Pro 1PM and Wave Pro 2PM

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->