### PR TITLE
Remove Shelly Wave Plug US update 13.0

### DIFF
--- a/firmwares/shelly/qnpl-001X16US.json
+++ b/firmwares/shelly/qnpl-001X16US.json
@@ -14,17 +14,6 @@
 	],
 	"upgrades": [
 		{
-			"version": "13.0",
-			"changelog": "- SDK with fixed dead node issue",
-			"region": "usa",
-			"files": [
-				{
-					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/b20d9850f6932b68c55252a100bdfcba558d7fbe/Wave_Plug_US/US/Wave_PlugUS_800_US_LR_20250204_1000_QNPL-001X16US_%5B13.00%5D_9DD2F96C.gbl",
-					"integrity": "sha256:608a54b1d9e1a2747411a28a4ed25cc9ff73f3492fa9c2ec73a1fa51d47f02a3"
-				}
-			]
-		},
-		{
 			"version": "10.11",
 			"changelog": "- optimised temperature conversion table\n- Meter Reset Command fixed\n- other minor improvements",
 			"region": "usa",


### PR DESCRIPTION
Removed version 13.0 upgrade details from the JSON file. File has issue can brick the device.

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->