### PR TITLE
Update Inovelli VZW32-SN, beta firmware 2.2

### DIFF
--- a/firmwares/inovelli/VZW32-SN.json
+++ b/firmwares/inovelli/VZW32-SN.json
@@ -10,6 +10,18 @@
 	],
 	"upgrades": [
 		{
+			"version": "2.2",
+			"channel": "beta",
+			"changelog": "Optimized the interaction logic between the switch and the mmWave module. Fixed the incorrect use of duration in the SwitchMultilevel Set command. When the switch is restarted, P240 will be reported to indicate that the switch has been restarted.",
+			"files": [
+				{
+					"target": 0,
+					"url": "https://files.inovelli.com/firmware/VZW32-SN/Beta/2.02/VZW32-SN_2.02.gbl",
+					"integrity": "sha256:e94a8ebe3ea87e25d00d6389cd411c2c797972ceb74bfbf4a272145723e30f85"
+				}
+			]
+		},
+		{
 			"version": "2.1",
 			"channel": "beta",
 			"changelog": "Fixed a situation where P101~P106 could not be configured correctly. Fixed the issue where meter energy would continue to increase even when the load was set to \"Off\".",

--- a/firmwares/inovelli/VZW32-SN.json
+++ b/firmwares/inovelli/VZW32-SN.json
@@ -12,7 +12,7 @@
 		{
 			"version": "2.2",
 			"channel": "beta",
-			"changelog": "Optimized the interaction logic between the switch and the mmWave module. Fixed the incorrect use of duration in the SwitchMultilevel Set command. When the switch is restarted, P240 will be reported to indicate that the switch has been restarted.",
+			"changelog": "- Optimized the interaction logic between the switch and the mmWave module.\n- Fixed the incorrect use of duration in the SwitchMultilevel Set command.\n- When the switch is restarted, P240 will be reported to indicate that the switch has been restarted.",
 			"files": [
 				{
 					"target": 0,

--- a/firmwares/inovelli/VZW32-SN.json
+++ b/firmwares/inovelli/VZW32-SN.json
@@ -22,18 +22,6 @@
 			]
 		},
 		{
-			"version": "2.1",
-			"channel": "beta",
-			"changelog": "Fixed a situation where P101~P106 could not be configured correctly. Fixed the issue where meter energy would continue to increase even when the load was set to \"Off\".",
-			"files": [
-				{
-					"target": 0,
-					"url": "https://github.com/InovelliUSA/Firmware/raw/5c324ee67348538c080b90000d28466f8afbd48b/Red-Series/Z-Wave/VZW32-SN-MMWave-Switch/Beta/2.01/VZW32-SN_2.01.gbl",
-					"integrity": "sha256:09aac2fc30c1daa6eacc44e83f1907d117e9aac54cfa77aa5d37359fa7ba7194"
-				}
-			]
-		},
-		{
 			"version": "2.0",
 			"channel": "stable",
 			"changelog": "Initial production release.",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->