### PR TITLE
fix(shelly): use firmware target 1 for Wave Plug S OTA updates

### DIFF
--- a/firmwares/shelly/qnpl-0A112EU.json
+++ b/firmwares/shelly/qnpl-0A112EU.json
@@ -19,6 +19,7 @@
 			"region": "europe",
 			"files": [
 				{
+					"target": 1,
 					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/7f92ad9cde6240d0d66eae213f81d38e7096ceff/Wave_Plug_S/EU/Wave_PlugS_800_EU_LR_20260205_1034_QLPL-0A112EU_%5B12.02%5D_0FE4B35C.gbl",
 					"integrity": "sha256:d6ff2545198f52f075d3024bebd7ce56d212dc65551eac874233eaf9503580a8"
 				}


### PR DESCRIPTION
## Summary

Fixes #334

The Shelly Wave Plug S (`0x0460 / 0x0002 / 0x0087`) OTA update fails with `Error_InvalidFirmwareTarget` after all 9856 fragments transmit successfully. This PR adds `"target": 1` to the version 12.2 files entry in `firmwares/shelly/qnpl-0A112EU.json`.

## Root cause

The device reports `additionalFirmwareIDs: [2]` during the node interview, which per Z-Wave spec means it has two OTA firmware targets:

- **Target 0**: main firmware (firmware ID from the main version report)
- **Target 1**: secondary firmware with firmware ID `2`

The current catalog entry for version 12.2 has no `target` field, so Z-Wave JS defaults to target 0. All fragments transmit without error (the transmission itself succeeds), but then the device rejects with `Error_InvalidFirmwareTarget` — the classic symptom of sending an image intended for a different slot.

The GBL binary is AES-encrypted (Silicon Labs Secure Boot), so the `ApplicationProperties_t` struct that would declare the intended target is not readable without vendor keys. The target must therefore be specified explicitly in the catalog.

## Change

In the `upgrades` array entry for version `"12.2"`, added `"target": 1` to the files entry. The version 11.4 entry is left unchanged as its target situation may differ.

```json
"files": [
  {
    "target": 1,
    "url": "...",
    "integrity": "..."
  }
]
```