### PR TITLE
Add Shelly Wave Dimmer, Door Window, H&T, Motion, Plug UK, Pro Dimmer 1PM, Pro Dimmer 2PM firmware updates for AUS/NZ and US regions

### DIFF
--- a/firmwares/shelly/qldm-0A101.json
+++ b/firmwares/shelly/qldm-0A101.json
@@ -15,7 +15,7 @@
 	"upgrades": [
 		{
 			"version": "12.3",
-			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working propely\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Other minor improvements",
+			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working properly\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Other minor improvements",
 			"region": "australia/new zealand",
 			"files": [
 				{
@@ -26,7 +26,7 @@
 		},
 		{
 			"version": "12.3",
-			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working propely\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Fix Detached mode Binary Switch when SW set to toggle\n- Improved Mosfet PWM\n- Other minor improvements",
+			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working properly\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Fix Detached mode Binary Switch when SW set to toggle\n- Improved Mosfet PWM\n- Other minor improvements",
 			"region": "europe",
 			"files": [
 				{
@@ -37,7 +37,7 @@
 		},
 		{
 			"version": "12.3",
-			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working propely\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Fix Detached mode Binary Switch when SW set to toggle\n- Improved Mosfet PWM\n- Other minor improvements",
+			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working properly\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Fix Detached mode Binary Switch when SW set to toggle\n- Improved Mosfet PWM\n- Other minor improvements",
 			"region": "usa",
 			"files": [
 				{

--- a/firmwares/shelly/qldm-0A101.json
+++ b/firmwares/shelly/qldm-0A101.json
@@ -15,6 +15,17 @@
 	"upgrades": [
 		{
 			"version": "12.3",
+			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working propely\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Other minor improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/02b1de27e912b88fe3020060b066001d3b90626c/Wave_Dimmer/ANZ/Wave_Dimmer_800_ANZ_20260120_1212_QNDM-0A101AUL_%5B12.03%5D_0FE4B35C.gbl",
+					"integrity": "sha256:c07f955e6f3d0a69268e7c8e220af651c349256e624e3455e03f69a8107598b8"
+				}
+			]
+		},
+		{
+			"version": "12.3",
 			"changelog": "- SDK with fixed dead node issue\n- fix Associations not working propely\n- fix Parameter 123 min dimming value\n- fix Meter CC missing on endpoint 1\n- fix double click not working according to specifications\n- Fix Detached mode Binary Switch when SW set to toggle\n- Improved Mosfet PWM\n- Other minor improvements",
 			"region": "europe",
 			"files": [

--- a/firmwares/shelly/qldw-002FC.json
+++ b/firmwares/shelly/qldw-002FC.json
@@ -15,7 +15,29 @@
 	"upgrades": [
 		{
 			"version": "11.9",
-			"changelog": "- Fixed Z-Wave node info during inclusion\n- Fixed parameter 157 - Default value\n- Fixed no comunication after inclusion state change\n- Fixed inclination bug\n- Improved Angle measuring\n- other minor improvements ",
+			"changelog": "- Fixed Z-Wave node info during inclusion\n- Fixed parameter 157 - Default value\n- Fixed no comunication after inclusion state change\n- Fixed inclination bug\n- Improved Angle measuring\n- other minor improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/d88014ae3cd8e58e88ee247c40f7211217efda7d/Wave_Door/Window/ANZ/Wave_Window_Door_Sensor_800_ANZ_20260623_1521_QNDW-002CAU_%5Bv11.09%5D_2144DF1C.gbl",
+					"integrity": "sha256:b95b3d2d46014f331b59be33d8b8c78643c8548fe1ed790862a653320799c10f"
+				}
+			]
+		},
+		{
+			"version": "11.9",
+			"changelog": "- Fixed Z-Wave node info during inclusion\n- Fixed parameter 157 - Default value\n- Fixed no comunication after inclusion state change\n- Fixed inclination bug\n- Improved Angle measuring\n- other minor improvements",
+			"region": "usa",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/d88014ae3cd8e58e88ee247c40f7211217efda7d/Wave_Door/Window/US/Wave_Window_Door_Sensor_800_US_LR_20260623_1520_QLDW-002CUS_%5Bv11.09%5D_2144DF1C.gbl",
+					"integrity": "sha256:82212979f741a0813d46ffbcc356be860e4bdfa259437373f3bfdf8aed8d6431"
+				}
+			]
+		},
+		{
+			"version": "11.9",
+			"changelog": "- Fixed Z-Wave node info during inclusion\n- Fixed parameter 157 - Default value\n- Fixed no comunication after inclusion state change\n- Fixed inclination bug\n- Improved Angle measuring\n- other minor improvements",
 			"region": "europe",
 			"files": [
 				{

--- a/firmwares/shelly/qlht-0U2Z.json
+++ b/firmwares/shelly/qlht-0U2Z.json
@@ -1,0 +1,50 @@
+{
+	"devices": [
+		{
+			"brand": "Shelly",
+			"model": "Wave H&T",
+			"manufacturerId": "0x0460",
+			"productType": "0x0100",
+			"productId": "0x0083",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "11.13",
+			"changelog": "- Fixed No communication after inclusion state change\n- Changed parameter 157 value\n- Improved Angle measuring\n- other fixes and improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_HT/ANZ/Wave_HT_800_AU_20260623_1518_QNHT-0U2ZAU_%5Bv11.13%5D_0FE4B35C.gbl",
+					"integrity": "sha256:052c949348b25cb6c9d1760bf2a7c7bfa910ebb4c97091b2092b39f66df06215"
+				}
+			]
+		},
+		{
+			"version": "11.13",
+			"changelog": "- Fixed No communication after inclusion state change\n- Changed parameter 157 value\n- Improved Angle measuring\n- other fixes and improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_HT/EU/Wave_HT_800_EU_LR_20252101_1100_QLHT-0U2ZEU_%5Bv11.13%5D_EB201890.gbl",
+					"integrity": "sha256:a25194dc9cd3d4a1db63fb75531a50ccc9ce9cc29b7eb21857221bbc16fbf667"
+				}
+			]
+		},
+		{
+			"version": "11.13",
+			"changelog": "- Fixed No communication after inclusion state change\n- Changed parameter 157 value\n- Improved Angle measuring\n- other fixes and improvements",
+			"region": "usa",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/main/Wave_HT/US/Wave_HT_800_US_LR_20260623_1516_QLHT-0U2ZUS_%5Bv11.13%5D_EB201890.gbl",
+					"integrity": "sha256:740530e8ceb6c6ca44f033834dccfe31b3b6881da53866ad5aa7805df314794f"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/shelly/qlmo-003F.json
+++ b/firmwares/shelly/qlmo-003F.json
@@ -15,7 +15,29 @@
 	"upgrades": [
 		{
 			"version": "11.10",
-			"changelog": "- Fixed OTA by adding sign and encription keys to post build rules\n- Fixed PIR sensor config\n- Fixed wake up Interval ignored\n- Fixed multilevel sensor read value to endpoint\n- Fixed wakeup intervals\n- Change sensitivity values of pir sensor\n- Change size of 159 parameter\n- other minor improvements",
+			"changelog": "- Fixed OTA and encryption keys\n- Fixed PIR sensor config\n- Fixed wake up Interval ignored\n- Fixed multilevel sensor read value to endpoint\n- Fixed wakeup intervals\n- Change sensitivity values of pir sensor\n- Change size of 159 parameter\n- other minor improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/2dd13b95f2fe86aab3f80ddb624568386af6abc4/Wave_Motion/ANZ/Wave_Motion_800_ANZ_20260303_0920_QNMO-003FAU_%5Bv11.10%5D_EB201890.gbl",
+					"integrity": "sha256:bb90b0f0c5e18b3c40c9d981f6d94000a8f54ccf0a2d7acb94324c8b286402d5"
+				}
+			]
+		},
+		{
+			"version": "11.10",
+			"changelog": "- Fixed OTA and encryption keys\n- Fixed PIR sensor config\n- Fixed wake up Interval ignored\n- Fixed multilevel sensor read value to endpoint\n- Fixed wakeup intervals\n- Change sensitivity values of pir sensor\n- Change size of 159 parameter\n- other minor improvements",
+			"region": "usa",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/2dd13b95f2fe86aab3f80ddb624568386af6abc4/Wave_Motion/US/Wave_Motion_800_US_LR_20260303_0921_QLMO-003FUS_%5Bv11.10%5D_2144DF1C.gbl",
+					"integrity": "sha256:53dcfd0a9238d214083b2bd403431b94de5e9736cdb6288b15a6fb601acd48d6"
+				}
+			]
+		},
+		{
+			"version": "11.10",
+			"changelog": "- Fixed OTA and encryption keys\n- Fixed PIR sensor config\n- Fixed wake up Interval ignored\n- Fixed multilevel sensor read value to endpoint\n- Fixed wakeup intervals\n- Change sensitivity values of pir sensor\n- Change size of 159 parameter\n- other minor improvements",
 			"region": "europe",
 			"files": [
 				{

--- a/firmwares/shelly/qnpl-001X12UK.json
+++ b/firmwares/shelly/qnpl-001X12UK.json
@@ -1,39 +1,39 @@
 {
-  "devices": [
-    {
-      "brand": "Shelly Qubino",
-      "model": "Wave Plug UK",
-      "manufacturerId": "0x0460",
-      "productType": "0x0002",
-      "productId": "0x0089",
-      "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-      }
-    }
-  ],
-  "upgrades": [
-    {
-      "version": "12.0",
-      "changelog": "- Fixed kWh report at boot-up\n- Fixed Par 105 min value 30 -> 0\n- Fixed Association group 2 triggered at S-Button push\n- Added User can enter setting mode at any time\n- Added kWh reset to 0 at factroy reset\n- Removed Voltage Meter Report\n- Removed Current Meter Report",
-      "region": "europe",
-      "files": [
-        {
-          "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/afe2c5478760576d6dfad356397ca7f1f18e5433/Wave_Plug_UK/EU/Wave_Plug_UK_800_EU_LR_20260309_1321_QLPL-001X12UK_%5B12.00%5D_0FE4B35C.gbl",
-          "integrity": "sha256:c976b673c32d55c484cf796bc823eee62417bdd7b859d065a4f3dd40a2d995ed"
-        }
-      ]
-    },
-    {
-      "version": "10.5",
-      "changelog": "- Fixed very low power reports\n- Improved voltage resolution\n- Meter report is now in mA (precision 3)\n- Added Association for Multilevel-Switch\n- other minor fixes and improvements",
-      "region": "europe",
-      "files": [
-        {
-          "url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl",
-          "integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc"
-        }
-      ]
-    }
-  ]
+	"devices": [
+		{
+			"brand": "Shelly Qubino",
+			"model": "Wave Plug UK",
+			"manufacturerId": "0x0460",
+			"productType": "0x0002",
+			"productId": "0x0089",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "12.0",
+			"changelog": "- Fixed kWh report at boot-up\n- Fixed Par 105 min value 30 -> 0\n- Fixed Association group 2 triggered at S-Button push\n- Added User can enter setting mode at any time\n- Added kWh reset to 0 at factory reset\n- Removed Voltage Meter Report\n- Removed Current Meter Report",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/afe2c5478760576d6dfad356397ca7f1f18e5433/Wave_Plug_UK/EU/Wave_Plug_UK_800_EU_LR_20260309_1321_QLPL-001X12UK_%5B12.00%5D_0FE4B35C.gbl",
+					"integrity": "sha256:c976b673c32d55c484cf796bc823eee62417bdd7b859d065a4f3dd40a2d995ed"
+				}
+			]
+		},
+		{
+			"version": "10.5",
+			"changelog": "- Fixed very low power reports\n- Improved voltage resolution\n- Meter report is now in mA (precision 3)\n- Added Association for Multilevel-Switch\n- other minor fixes and improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl",
+					"integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc"
+				}
+			]
+		}
+	]
 }

--- a/firmwares/shelly/qnpl-001X12UK.json
+++ b/firmwares/shelly/qnpl-001X12UK.json
@@ -1,28 +1,39 @@
 {
-	"devices": [
-		{
-			"brand": "Shelly Qubino",
-			"model": "Wave Plug UK",
-			"manufacturerId": "0x0460",
-			"productType": "0x0002",
-			"productId": "0x0089",
-			"firmwareVersion": {
-				"min": "0.0",
-				"max": "255.255"
-			}
-		}
-	],
-	"upgrades": [
-		{
-			"version": "10.5",
-			"changelog": "- Fixed very low power reports\n- Improved voltage resolution\n- Meter report is now in mA (precision 3)\n- Added Association for Multilevel-Switch\n- other minor fixes and improvements",
-			"region": "europe",
-			"files": [
-				{
-					"url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl",
-					"integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc"
-				}
-			]
-		}
-	]
+  "devices": [
+    {
+      "brand": "Shelly Qubino",
+      "model": "Wave Plug UK",
+      "manufacturerId": "0x0460",
+      "productType": "0x0002",
+      "productId": "0x0089",
+      "firmwareVersion": {
+        "min": "0.0",
+        "max": "255.255"
+      }
+    }
+  ],
+  "upgrades": [
+    {
+      "version": "12.0",
+      "changelog": "- Fixed kWh report at boot-up\n- Fixed Par 105 min value 30 -> 0\n- Fixed Association group 2 triggered at S-Button push\n- Added User can enter setting mode at any time\n- Added kWh reset to 0 at factroy reset\n- Removed Voltage Meter Report\n- Removed Current Meter Report",
+      "region": "europe",
+      "files": [
+        {
+          "url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/afe2c5478760576d6dfad356397ca7f1f18e5433/Wave_Plug_UK/EU/Wave_Plug_UK_800_EU_LR_20260309_1321_QLPL-001X12UK_%5B12.00%5D_0FE4B35C.gbl",
+          "integrity": "sha256:c976b673c32d55c484cf796bc823eee62417bdd7b859d065a4f3dd40a2d995ed"
+        }
+      ]
+    },
+    {
+      "version": "10.5",
+      "changelog": "- Fixed very low power reports\n- Improved voltage resolution\n- Meter report is now in mA (precision 3)\n- Added Association for Multilevel-Switch\n- other minor fixes and improvements",
+      "region": "europe",
+      "files": [
+        {
+          "url": "https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/raw/01a5da2e65b62dcc10406bdb584ebc9970c03c38/Wave_Plug_UK/EU/Wave_PlugUk_800_EU_20240224_1014_QNPL-001X12UK_%5B10.05%5D_0FE4B35C.gbl",
+          "integrity": "sha256:7f951160a2c1a106ff51adaddc9d02def3042c4b572f938965230fe49dd9eccc"
+        }
+      ]
+    }
+  ]
 }

--- a/firmwares/shelly/qpdm-0A1P01.json
+++ b/firmwares/shelly/qpdm-0A1P01.json
@@ -1,0 +1,50 @@
+{
+	"devices": [
+		{
+			"brand": "Shelly",
+			"model": "Wave Pro Dimmer 1PM",
+			"manufacturerId": "0x0460",
+			"productType": "0x0001",
+			"productId": "0x0081",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "12.2",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Inclusion over inputs\n- Fixed Associations\n- Fixed Soft reset loop\n- other minor fixes and improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/8697a36fafa4caf58729157b52431865b4672845/Wave_Pro_Dimmer_1PM/ANZ/Wave_PRO_Dimmer_1PM_ANZ_20260217_0905_QPDM-0A1P01AU_%5Bv12.02%5D_2144DF1C.gbl",
+					"integrity": "sha256:f61ced8e247607f1fe360e53226a4b26c8b051fb768c8a9b7147f66ede939468"
+				}
+			]
+		},
+		{
+			"version": "12.2",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Inclusion over inputs\n- Fixed Associations\n- Fixed Soft reset loop\n- other minor fixes and improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/8697a36fafa4caf58729157b52431865b4672845/Wave_Pro_Dimmer_1PM/EU/Wave_PRO_Dimmer_1PM_EU_LR_20260211_0904_QUDM-0A1P01EU_%5Bv12.02%5D_EB201890.gbl",
+					"integrity": "sha256:f9ed516321d4ac78b14439fcef116fdc35f619022c319f8dbd10df5699bc644f"
+				}
+			]
+		},
+		{
+			"version": "12.2",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Inclusion over inputs\n- Fixed Associations\n- Fixed Soft reset loop\n- other minor fixes and improvements",
+			"region": "usa",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/8697a36fafa4caf58729157b52431865b4672845/Wave_Pro_Dimmer_1PM/US/Wave_PRO_Dimmer_1PM_US_LR_20260216_1500_QUDM-0A1P01US_%5Bv12.02%5D_2144DF1C.gbl",
+					"integrity": "sha256:d5b8d613dfbf59322c8f3f64b4dec1d854f764e12ae75e1bee523d369d2d6b37"
+				}
+			]
+		}
+	]
+}

--- a/firmwares/shelly/qpdm-0A2P01.json
+++ b/firmwares/shelly/qpdm-0A2P01.json
@@ -1,0 +1,50 @@
+{
+	"devices": [
+		{
+			"brand": "Shelly",
+			"model": "Wave Pro Dimmer 2PM",
+			"manufacturerId": "0x0460",
+			"productType": "0x0001",
+			"productId": "0x0082",
+			"firmwareVersion": {
+				"min": "0.0",
+				"max": "255.255"
+			}
+		}
+	],
+	"upgrades": [
+		{
+			"version": "12.7",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Inclusion over inputs\n- Fixed part number\n- Fixed Associations not working properly\n- Fixed Meter CC\n- Fixed last on value\n- Fixed avoid switch ON after SmartStart\n- Fixed switch multilevel root\n- Fixed auto off timer not working\n- Improved calibration range\n- other minor fixes and improvements",
+			"region": "australia/new zealand",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/8697a36fafa4caf58729157b52431865b4672845/Wave_Pro_Dimmer_2PM/ANZ/Wave_PRO_Dimmer_2PM_ANZ_20250217_0905_QPDM-0A2P01AU_%5Bv12.07%5D_2144DF1C.gbl",
+					"integrity": "sha256:8719cf8f30ff859757df7a303715c43f9d00fb953de1b946fd967fff709002da"
+				}
+			]
+		},
+		{
+			"version": "12.7",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Inclusion over inputs\n- Fixed part number\n- Fixed Associations not working properly\n- Fixed Meter CC\n- Fixed last on value\n- Fixed avoid switch ON after SmartStart\n- Fixed switch multilevel root\n- Fixed auto off timer not working\n- Improved calibration range\n- other minor fixes and improvements",
+			"region": "europe",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/8697a36fafa4caf58729157b52431865b4672845/Wave_Pro_Dimmer_2PM/EU/Wave_PRO_Dimmer_2PM_EU_LR_20250209_1705_QUDM-0A2P01EU_%5Bv12.07%5D_2144DF1C.gbl",
+					"integrity": "sha256:d9ac700fabc3501ddc12617ea31f21efe3ffb24d8769aebc68ac74e4a502d92c"
+				}
+			]
+		},
+		{
+			"version": "12.7",
+			"changelog": "- SDK with fixed dead node issue\n- Fixed Inclusion over inputs\n- Fixed part number\n- Fixed Associations not working properly\n- Fixed Meter CC\n- Fixed last on value\n- Fixed avoid switch ON after SmartStart\n- Fixed switch multilevel root\n- Fixed auto off timer not working\n- Improved calibration range\n- other minor fixes and improvements",
+			"region": "usa",
+			"files": [
+				{
+					"url": "https://raw.githubusercontent.com/QubinoHelp/Shelly_Wave_FW_OTA/8697a36fafa4caf58729157b52431865b4672845/Wave_Pro_Dimmer_2PM/US/Wave_PRO_Dimmer_2PM_US_LR_20250216_1420_QUDM-0A2P01US_%5Bv12.07%5D_2144DF1C.gbl",
+					"integrity": "sha256:045cdb116efeaba4de6ba6c106f7ee04b79de5e1f90f5001fc83ddd7eac47c0c"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Wave H&T, Wave Plug UK, Wave Pro Dimmer 1PM, Wave Pro Dimmer 2PM

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->