### PR TITLE
Add several Jasco and Ultrapro firmware updates

### DIFF
--- a/firmwares/jasco/ZW4006_24770.json
+++ b/firmwares/jasco/ZW4006_24770.json
@@ -4,15 +4,11 @@
 			"brand": "Jasco",
 			"model": "ZW4006 / 24770",
 			"manufacturerId": "0x0063",
-			"productType": "0x494D",
+			"productType": "0x494d",
 			"productId": "0x3031"
 		}
 	],
 	"upgrades": [
-		{
-			"version": "5.28",
-			"changelog": "Original Release Firmware"
-		},
 		{
 			"version": "5.39",
 			"changelog": "Changed button press behavior: If the button is pressed and held for more than 0.5s, the light will turn on/off at the 0.5s mark. Then, if the button is released before the 3s mark, no further operation will be done. If the button is held for more than 3s, it will change the timeout duration setting.",

--- a/firmwares/jasco/ZW4006_24770.json
+++ b/firmwares/jasco/ZW4006_24770.json
@@ -1,0 +1,23 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZW4006 / 24770",
+			"manufacturerId": "0x0063",
+			"productType": "0x494D",
+			"productId": "0x3031"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "5.28",
+			"changelog": "1. Original Release Firmware"
+		},
+		{
+			"version": "5.39",
+			"changelog": "1. Changed button press behavior: If the button is pressed and held for more than 0.5s, the light will turn on/off at the 0.5s mark. Then, if the button is released before the 3s mark, no further operation will be done. If the button is held for more than 3s, it will change the timeout duration setting.",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/refs/heads/main/zwave/Jasco/ZW4006/24770%20-%20In-Wall%20Motion%20Switch%2C%20500S/5.39/ZW4006_Jasco_24770_5.39.hex",
+			"integrity": "sha256:9de131688516ab2bba500509c5ceee96022efd1d926efdc44bcc7122e5f860c2"
+		}
+	]
+}

--- a/firmwares/jasco/ZW4006_24770.json
+++ b/firmwares/jasco/ZW4006_24770.json
@@ -16,7 +16,7 @@
 		{
 			"version": "5.39",
 			"changelog": "1. Changed button press behavior: If the button is pressed and held for more than 0.5s, the light will turn on/off at the 0.5s mark. Then, if the button is released before the 3s mark, no further operation will be done. If the button is held for more than 3s, it will change the timeout duration setting.",
-			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/refs/heads/main/zwave/Jasco/ZW4006/24770%20-%20In-Wall%20Motion%20Switch%2C%20500S/5.39/ZW4006_Jasco_24770_5.39.hex",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZW4006/24770%20-%20In-Wall%20Motion%20Switch%2C%20500S/5.39/ZW4006_Jasco_24770_5.39.hex",
 			"integrity": "sha256:9de131688516ab2bba500509c5ceee96022efd1d926efdc44bcc7122e5f860c2"
 		}
 	]

--- a/firmwares/jasco/ZW4006_24770.json
+++ b/firmwares/jasco/ZW4006_24770.json
@@ -11,11 +11,11 @@
 	"upgrades": [
 		{
 			"version": "5.28",
-			"changelog": "1. Original Release Firmware"
+			"changelog": "Original Release Firmware"
 		},
 		{
 			"version": "5.39",
-			"changelog": "1. Changed button press behavior: If the button is pressed and held for more than 0.5s, the light will turn on/off at the 0.5s mark. Then, if the button is released before the 3s mark, no further operation will be done. If the button is held for more than 3s, it will change the timeout duration setting.",
+			"changelog": "Changed button press behavior: If the button is pressed and held for more than 0.5s, the light will turn on/off at the 0.5s mark. Then, if the button is released before the 3s mark, no further operation will be done. If the button is held for more than 3s, it will change the timeout duration setting.",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZW4006/24770%20-%20In-Wall%20Motion%20Switch%2C%20500S/5.39/ZW4006_Jasco_24770_5.39.hex",
 			"integrity": "sha256:9de131688516ab2bba500509c5ceee96022efd1d926efdc44bcc7122e5f860c2"
 		}

--- a/firmwares/jasco/ZWA1003_59387.json
+++ b/firmwares/jasco/ZWA1003_59387.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWA1003 / 59387",
+			"manufacturerId": "0x0063",
+			"productType": "0x4952",
+			"productId": "0x3434"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.07",
+			"changelog": "1. Original Release Firmware",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA1003/59387%20-%20In-Wall%20Outlet,%20TR,%20700S/1.07/ZWA1003_Enbrighten_58449_1.07.gbl",
+			"integrity": "sha256:680a5dd80b4c6a82b7f9247dd6d5095a7ae14fe11aa2496b02c2f70e1ce00bca"
+		}
+	]
+}

--- a/firmwares/jasco/ZWA1003_59387.json
+++ b/firmwares/jasco/ZWA1003_59387.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "1.07",
-			"changelog": "1. Original Release Firmware",
+			"changelog": "Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA1003/59387%20-%20In-Wall%20Outlet%2C%20TR%2C%20700S/1.07/ZWA1003_Enbrighten_58449_1.07.gbl",
 			"integrity": "sha256:680a5dd80b4c6a82b7f9247dd6d5095a7ae14fe11aa2496b02c2f70e1ce00bca"
 		}

--- a/firmwares/jasco/ZWA1003_59387.json
+++ b/firmwares/jasco/ZWA1003_59387.json
@@ -10,7 +10,7 @@
 	],
 	"upgrades": [
 		{
-			"version": "1.07",
+			"version": "1.7",
 			"changelog": "Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA1003/59387%20-%20In-Wall%20Outlet%2C%20TR%2C%20700S/1.07/ZWA1003_Enbrighten_58449_1.07.gbl",
 			"integrity": "sha256:680a5dd80b4c6a82b7f9247dd6d5095a7ae14fe11aa2496b02c2f70e1ce00bca"

--- a/firmwares/jasco/ZWA1003_59387.json
+++ b/firmwares/jasco/ZWA1003_59387.json
@@ -12,7 +12,7 @@
 		{
 			"version": "1.07",
 			"changelog": "1. Original Release Firmware",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA1003/59387%20-%20In-Wall%20Outlet,%20TR,%20700S/1.07/ZWA1003_Enbrighten_58449_1.07.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA1003/59387%20-%20In-Wall%20Outlet%2C%20TR%2C%20700S/1.07/ZWA1003_Enbrighten_58449_1.07.gbl",
 			"integrity": "sha256:680a5dd80b4c6a82b7f9247dd6d5095a7ae14fe11aa2496b02c2f70e1ce00bca"
 		}
 	]

--- a/firmwares/jasco/ZWA3016_59383.json
+++ b/firmwares/jasco/ZWA3016_59383.json
@@ -1,0 +1,31 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWA3016 / 59383",
+			"manufacturerId": "0x0063",
+			"productType": "0x4944",
+			"productId": "0x3434"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.23",
+			"changelog": "",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.23/ZWA3016_Jasco_59383_1.23.gbl",
+			"integrity": "sha256:16eb4eae22724e90a7e9a141c2a5f0246847fffebb5e0fea674ba6bbaf2b16bf"
+		},
+		{
+			"version": "1.24",
+			"changelog": "1. Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.24/ZWA3016_Jasco_59383_1.24.gbl",
+			"integrity": "sha256:430bb1602a2dad55588af1505a7abc609c17bad5bb5f2860ec75f3b231cc1537"
+		},
+		{
+			"version": "1.25",
+			"changelog": "1. Shortened dimming speed from 1-100 to 10 seconds\n2. Updated to ignore invalid zero value for parameters 30, 31, 34, 35 and 36",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.25/ZWA3016_Jasco_59383_1.25.gbl",
+			"integrity": "sha256:17e050705d8a79f14e14ebd6234b6b682c93ea0904f0a8f12ad49be4fb06a63c"
+		}
+	]
+}

--- a/firmwares/jasco/ZWA3016_59383.json
+++ b/firmwares/jasco/ZWA3016_59383.json
@@ -12,19 +12,19 @@
 		{
 			"version": "1.23",
 			"changelog": "",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.23/ZWA3016_Jasco_59383_1.23.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.23/ZWA3016_Jasco_59383_1.23.gbl",
 			"integrity": "sha256:16eb4eae22724e90a7e9a141c2a5f0246847fffebb5e0fea674ba6bbaf2b16bf"
 		},
 		{
 			"version": "1.24",
 			"changelog": "1. Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.24/ZWA3016_Jasco_59383_1.24.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.24/ZWA3016_Jasco_59383_1.24.gbl",
 			"integrity": "sha256:430bb1602a2dad55588af1505a7abc609c17bad5bb5f2860ec75f3b231cc1537"
 		},
 		{
 			"version": "1.25",
 			"changelog": "1. Shortened dimming speed from 1-100 to 10 seconds\n2. Updated to ignore invalid zero value for parameters 30, 31, 34, 35 and 36",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.25/ZWA3016_Jasco_59383_1.25.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.25/ZWA3016_Jasco_59383_1.25.gbl",
 			"integrity": "sha256:17e050705d8a79f14e14ebd6234b6b682c93ea0904f0a8f12ad49be4fb06a63c"
 		}
 	]

--- a/firmwares/jasco/ZWA3016_59383.json
+++ b/firmwares/jasco/ZWA3016_59383.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"version": "1.24",
-			"changelog": "1. Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
+			"changelog": "Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.24/ZWA3016_Jasco_59383_1.24.gbl",
 			"integrity": "sha256:430bb1602a2dad55588af1505a7abc609c17bad5bb5f2860ec75f3b231cc1537"
 		},

--- a/firmwares/jasco/ZWA3016_59383.json
+++ b/firmwares/jasco/ZWA3016_59383.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "1.23",
-			"changelog": "",
+			"changelog": "Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3016/59383%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.23/ZWA3016_Jasco_59383_1.23.gbl",
 			"integrity": "sha256:16eb4eae22724e90a7e9a141c2a5f0246847fffebb5e0fea674ba6bbaf2b16bf"
 		},

--- a/firmwares/jasco/ZWA3017_59384.json
+++ b/firmwares/jasco/ZWA3017_59384.json
@@ -12,19 +12,19 @@
 		{
 			"version": "1.23",
 			"changelog": "1. Original Release Firmware",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer,%20700S/1.23/ZWA3017_Jasco_59384_1.23.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer%2C%20700S/1.23/ZWA3017_Jasco_59384_1.23.gbl",
 			"integrity": "sha256:05ed8bce8dcf50e5fdf97ba25abe1ba633967da67bec6f227e9c206a201fff33"
 		},
 		{
 			"version": "1.24",
 			"changelog": "1. Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer,%20700S/1.24/ZWA3017_Jasco_59384_1.24.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer%2C%20700S/1.24/ZWA3017_Jasco_59384_1.24.gbl",
 			"integrity": "sha256:430bb1602a2dad55588af1505a7abc609c17bad5bb5f2860ec75f3b231cc1537"
 		},
 		{
 			"version": "1.25",
 			"changelog": "1. Shortened dimming speed from 1-100 to 10 seconds\n2. Updated to ignore invalid zero value for parameters 30, 31, 34, 35 and 36",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer,%20700S/1.25/ZWA3017_Jasco_59384_1.25.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer%2C%20700S/1.25/ZWA3017_Jasco_59384_1.25.gbl",
 			"integrity": "sha256:17e050705d8a79f14e14ebd6234b6b682c93ea0904f0a8f12ad49be4fb06a63c"
 		}
 	]

--- a/firmwares/jasco/ZWA3017_59384.json
+++ b/firmwares/jasco/ZWA3017_59384.json
@@ -1,0 +1,31 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWA3017 / 59384",
+			"manufacturerId": "0x0063",
+			"productType": "0x4944",
+			"productId": "0x3435"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.23",
+			"changelog": "1. Original Release Firmware",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer,%20700S/1.23/ZWA3017_Jasco_59384_1.23.gbl",
+			"integrity": "sha256:05ed8bce8dcf50e5fdf97ba25abe1ba633967da67bec6f227e9c206a201fff33"
+		},
+		{
+			"version": "1.24",
+			"changelog": "1. Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer,%20700S/1.24/ZWA3017_Jasco_59384_1.24.gbl",
+			"integrity": "sha256:430bb1602a2dad55588af1505a7abc609c17bad5bb5f2860ec75f3b231cc1537"
+		},
+		{
+			"version": "1.25",
+			"changelog": "1. Shortened dimming speed from 1-100 to 10 seconds\n2. Updated to ignore invalid zero value for parameters 30, 31, 34, 35 and 36",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer,%20700S/1.25/ZWA3017_Jasco_59384_1.25.gbl",
+			"integrity": "sha256:17e050705d8a79f14e14ebd6234b6b682c93ea0904f0a8f12ad49be4fb06a63c"
+		}
+	]
+}

--- a/firmwares/jasco/ZWA3017_59384.json
+++ b/firmwares/jasco/ZWA3017_59384.json
@@ -11,13 +11,13 @@
 	"upgrades": [
 		{
 			"version": "1.23",
-			"changelog": "1. Original Release Firmware",
+			"changelog": "Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer%2C%20700S/1.23/ZWA3017_Jasco_59384_1.23.gbl",
 			"integrity": "sha256:05ed8bce8dcf50e5fdf97ba25abe1ba633967da67bec6f227e9c206a201fff33"
 		},
 		{
 			"version": "1.24",
-			"changelog": "1. Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
+			"changelog": "Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA3017/59384%20-%20In-Wall%20Toggle%20Dimmer%2C%20700S/1.24/ZWA3017_Jasco_59384_1.24.gbl",
 			"integrity": "sha256:430bb1602a2dad55588af1505a7abc609c17bad5bb5f2860ec75f3b231cc1537"
 		},

--- a/firmwares/jasco/ZWA4011_59381.json
+++ b/firmwares/jasco/ZWA4011_59381.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWA4011 / 59381",
+			"manufacturerId": "0x0063",
+			"productType": "0x4952",
+			"productId": "0x3335"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.22",
+			"changelog": "1. Original Release Firmware",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA4011/59381%20-%20In-Wall%20Paddle%20Switch,%20700S/1.22/ZWA4011_Jasco_59381_1.22.gbl",
+			"integrity": "sha256:c0ba8a21d80a518a7f6321ac70c46c4a7a585eed9a6de904d96c3aa4380927e8"
+		}
+	]
+}

--- a/firmwares/jasco/ZWA4011_59381.json
+++ b/firmwares/jasco/ZWA4011_59381.json
@@ -12,7 +12,7 @@
 		{
 			"version": "1.22",
 			"changelog": "1. Original Release Firmware",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA4011/59381%20-%20In-Wall%20Paddle%20Switch,%20700S/1.22/ZWA4011_Jasco_59381_1.22.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA4011/59381%20-%20In-Wall%20Paddle%20Switch%2C%20700S/1.22/ZWA4011_Jasco_59381_1.22.gbl",
 			"integrity": "sha256:c0ba8a21d80a518a7f6321ac70c46c4a7a585eed9a6de904d96c3aa4380927e8"
 		}
 	]

--- a/firmwares/jasco/ZWA4011_59381.json
+++ b/firmwares/jasco/ZWA4011_59381.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "1.22",
-			"changelog": "1. Original Release Firmware",
+			"changelog": "Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA4011/59381%20-%20In-Wall%20Paddle%20Switch%2C%20700S/1.22/ZWA4011_Jasco_59381_1.22.gbl",
 			"integrity": "sha256:c0ba8a21d80a518a7f6321ac70c46c4a7a585eed9a6de904d96c3aa4380927e8"
 		}

--- a/firmwares/jasco/ZWA4012_59382.json
+++ b/firmwares/jasco/ZWA4012_59382.json
@@ -12,7 +12,7 @@
 		{
 			"version": "1.22",
 			"changelog": "1. Original Release Firmware",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA4012/59382%20-%20In-Wall%20Toggle%20Switch,%20700S/1.22/ZWA4012_Jasco_59382_1.22.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA4012/59382%20-%20In-Wall%20Toggle%20Switch%2C%20700S/1.22/ZWA4012_Jasco_59382_1.22.gbl",
 			"integrity": "sha256:48a94b7c87741f9127fd56bdd5ce39250d886d4641ee8f8c7ae8e36759b2dbce"
 		}
 	]

--- a/firmwares/jasco/ZWA4012_59382.json
+++ b/firmwares/jasco/ZWA4012_59382.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "1.22",
-			"changelog": "1. Original Release Firmware",
+			"changelog": "Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWA4012/59382%20-%20In-Wall%20Toggle%20Switch%2C%20700S/1.22/ZWA4012_Jasco_59382_1.22.gbl",
 			"integrity": "sha256:48a94b7c87741f9127fd56bdd5ce39250d886d4641ee8f8c7ae8e36759b2dbce"
 		}

--- a/firmwares/jasco/ZWA4012_59382.json
+++ b/firmwares/jasco/ZWA4012_59382.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWA4012 / 59382",
+			"manufacturerId": "0x0063",
+			"productType": "0x4952",
+			"productId": "0x3336"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.22",
+			"changelog": "1. Original Release Firmware",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWA4012/59382%20-%20In-Wall%20Toggle%20Switch,%20700S/1.22/ZWA4012_Jasco_59382_1.22.gbl",
+			"integrity": "sha256:48a94b7c87741f9127fd56bdd5ce39250d886d4641ee8f8c7ae8e36759b2dbce"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN3018_76597.json
+++ b/firmwares/jasco/ZWN3018_76597.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWN3018 / 76597",
+			"manufacturerId": "0x0063",
+			"productType": "0x4944",
+			"productId": "0x3539"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.20",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN3018/76597%20-%20In-Wall%20Paddle%20Dimmer,%20800S/8.20/ZWN3018_Jasco_76597_8.20.gbl",
+			"integrity": "sha256:876ecd808c664a1456afe28bffb2702d3af67ec95fa5eb3c18dc3ac9ff6d18f9"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN3018_76597.json
+++ b/firmwares/jasco/ZWN3018_76597.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "8.20",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN3018/76597%20-%20In-Wall%20Paddle%20Dimmer%2C%20800S/8.20/ZWN3018_Jasco_76597_8.20.gbl",
 			"integrity": "sha256:876ecd808c664a1456afe28bffb2702d3af67ec95fa5eb3c18dc3ac9ff6d18f9"
 		}

--- a/firmwares/jasco/ZWN3018_76597.json
+++ b/firmwares/jasco/ZWN3018_76597.json
@@ -12,7 +12,7 @@
 		{
 			"version": "8.20",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN3018/76597%20-%20In-Wall%20Paddle%20Dimmer,%20800S/8.20/ZWN3018_Jasco_76597_8.20.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN3018/76597%20-%20In-Wall%20Paddle%20Dimmer%2C%20800S/8.20/ZWN3018_Jasco_76597_8.20.gbl",
 			"integrity": "sha256:876ecd808c664a1456afe28bffb2702d3af67ec95fa5eb3c18dc3ac9ff6d18f9"
 		}
 	]

--- a/firmwares/jasco/ZWN3019_76599.json
+++ b/firmwares/jasco/ZWN3019_76599.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWN3019 / 76599",
+			"manufacturerId": "0x0063",
+			"productType": "0x4944",
+			"productId": "0x3631"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.11",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN3019/76599%20-%20In-Wall%20Toggle%20Dimmer,%20800S/8.11/ZWN3019_Jasco_76599_8.11.gbl",
+			"integrity": "sha256:416b8e2bbbefc58331eb97f7e4f094ba6d5ee6ad67c665e9ea04164a96ddd77c"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN3019_76599.json
+++ b/firmwares/jasco/ZWN3019_76599.json
@@ -12,7 +12,7 @@
 		{
 			"version": "8.11",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN3019/76599%20-%20In-Wall%20Toggle%20Dimmer,%20800S/8.11/ZWN3019_Jasco_76599_8.11.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN3019/76599%20-%20In-Wall%20Toggle%20Dimmer%2C%20800S/8.11/ZWN3019_Jasco_76599_8.11.gbl",
 			"integrity": "sha256:416b8e2bbbefc58331eb97f7e4f094ba6d5ee6ad67c665e9ea04164a96ddd77c"
 		}
 	]

--- a/firmwares/jasco/ZWN3019_76599.json
+++ b/firmwares/jasco/ZWN3019_76599.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "8.11",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN3019/76599%20-%20In-Wall%20Toggle%20Dimmer%2C%20800S/8.11/ZWN3019_Jasco_76599_8.11.gbl",
 			"integrity": "sha256:416b8e2bbbefc58331eb97f7e4f094ba6d5ee6ad67c665e9ea04164a96ddd77c"
 		}

--- a/firmwares/jasco/ZWN3109_76723.json
+++ b/firmwares/jasco/ZWN3109_76723.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWN3109 / 76723",
+			"manufacturerId": "0x0063",
+			"productType": "0x5044",
+			"productId": "0x3137"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.20",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN3109/76723%20-%20Plug-in%202-Outlet%20Dimmer,%201%20Controlled,%20800S/8.20/ZWN3109_Jasco_76723_8.20.gbl",
+			"integrity": "sha256:0657d75be7e7b74dfccef99b094ef4e3049e33858b6144d73f5317eb82cf66a7"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN3109_76723.json
+++ b/firmwares/jasco/ZWN3109_76723.json
@@ -12,7 +12,7 @@
 		{
 			"version": "8.20",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN3109/76723%20-%20Plug-in%202-Outlet%20Dimmer,%201%20Controlled,%20800S/8.20/ZWN3109_Jasco_76723_8.20.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN3109/76723%20-%20Plug-in%202-Outlet%20Dimmer%2C%201%20Controlled%2C%20800S/8.20/ZWN3109_Jasco_76723_8.20.gbl",
 			"integrity": "sha256:0657d75be7e7b74dfccef99b094ef4e3049e33858b6144d73f5317eb82cf66a7"
 		}
 	]

--- a/firmwares/jasco/ZWN3109_76723.json
+++ b/firmwares/jasco/ZWN3109_76723.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "8.20",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN3109/76723%20-%20Plug-in%202-Outlet%20Dimmer%2C%201%20Controlled%2C%20800S/8.20/ZWN3109_Jasco_76723_8.20.gbl",
 			"integrity": "sha256:0657d75be7e7b74dfccef99b094ef4e3049e33858b6144d73f5317eb82cf66a7"
 		}

--- a/firmwares/jasco/ZWN4015_76596.json
+++ b/firmwares/jasco/ZWN4015_76596.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWN4015 / 76596",
+			"manufacturerId": "0x0063",
+			"productType": "0x4952",
+			"productId": "0x3437"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.11",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4015/76596%20-%20In-Wall%20Paddle%20Switch,%20800S/8.11/ZWN4015_Jasco_76596_8.11.gbl",
+			"integrity": "sha256:ee1d556eb1b80f0c13f3684fe377bd2039439cce3cd4c53b95cbec34c1514123"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN4015_76596.json
+++ b/firmwares/jasco/ZWN4015_76596.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "8.11",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4015/76596%20-%20In-Wall%20Paddle%20Switch%2C%20800S/8.11/ZWN4015_Jasco_76596_8.11.gbl",
 			"integrity": "sha256:ee1d556eb1b80f0c13f3684fe377bd2039439cce3cd4c53b95cbec34c1514123"
 		}

--- a/firmwares/jasco/ZWN4015_76596.json
+++ b/firmwares/jasco/ZWN4015_76596.json
@@ -12,7 +12,7 @@
 		{
 			"version": "8.11",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4015/76596%20-%20In-Wall%20Paddle%20Switch,%20800S/8.11/ZWN4015_Jasco_76596_8.11.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4015/76596%20-%20In-Wall%20Paddle%20Switch%2C%20800S/8.11/ZWN4015_Jasco_76596_8.11.gbl",
 			"integrity": "sha256:ee1d556eb1b80f0c13f3684fe377bd2039439cce3cd4c53b95cbec34c1514123"
 		}
 	]

--- a/firmwares/jasco/ZWN4016_76598.json
+++ b/firmwares/jasco/ZWN4016_76598.json
@@ -16,7 +16,7 @@
 		{
 			"version": "8.20",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4016/76598%20-%20In-Wall%20Toggle%20Switch,%20800S/8.20/ZWN4016_Jasco_76598_8.20.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4016/76598%20-%20In-Wall%20Toggle%20Switch%2C%20800S/8.20/ZWN4016_Jasco_76598_8.20.gbl",
 			"integrity": "sha256:e1ee4a4355e0035edc0652ddd05b4b6cc099a9d69c9be14b1ef28a46c7152d95"
 		}
 	]

--- a/firmwares/jasco/ZWN4016_76598.json
+++ b/firmwares/jasco/ZWN4016_76598.json
@@ -1,0 +1,23 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWN4016 / 76598",
+			"manufacturerId": "0x0063",
+			"productType": "0x4952",
+			"productId": "0x3530"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.10",
+			"changelog": "1. Original Release Firmware"
+		},
+		{
+			"version": "8.20",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4016/76598%20-%20In-Wall%20Toggle%20Switch,%20800S/8.20/ZWN4016_Jasco_76598_8.20.gbl",
+			"integrity": "sha256:e1ee4a4355e0035edc0652ddd05b4b6cc099a9d69c9be14b1ef28a46c7152d95"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN4016_76598.json
+++ b/firmwares/jasco/ZWN4016_76598.json
@@ -10,10 +10,6 @@
 	],
 	"upgrades": [
 		{
-			"version": "8.10",
-			"changelog": "Original Release Firmware"
-		},
-		{
 			"version": "8.20",
 			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4016/76598%20-%20In-Wall%20Toggle%20Switch%2C%20800S/8.20/ZWN4016_Jasco_76598_8.20.gbl",

--- a/firmwares/jasco/ZWN4016_76598.json
+++ b/firmwares/jasco/ZWN4016_76598.json
@@ -11,11 +11,11 @@
 	"upgrades": [
 		{
 			"version": "8.10",
-			"changelog": "1. Original Release Firmware"
+			"changelog": "Original Release Firmware"
 		},
 		{
 			"version": "8.20",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4016/76598%20-%20In-Wall%20Toggle%20Switch%2C%20800S/8.20/ZWN4016_Jasco_76598_8.20.gbl",
 			"integrity": "sha256:e1ee4a4355e0035edc0652ddd05b4b6cc099a9d69c9be14b1ef28a46c7152d95"
 		}

--- a/firmwares/jasco/ZWN4108_76724.json
+++ b/firmwares/jasco/ZWN4108_76724.json
@@ -11,11 +11,11 @@
 	"upgrades": [
 		{
 			"version": "8.10",
-			"changelog": "1. Original Release Firmware"
+			"changelog": "Original Release Firmware"
 		},
 		{
 			"version": "8.20",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4108/76724%20-%20Plug-in%202-Outlet%20Switch%2C%201%20Controlled%2C%20800S/8.20/ZWN4108_Jasco_76724_8.20.gbl",
 			"integrity": "sha256:2ed579bb0e05b4d6d9c75a407c3bfc2e7748829bdaa88d92391a7031fc05b4c5"
 		}

--- a/firmwares/jasco/ZWN4108_76724.json
+++ b/firmwares/jasco/ZWN4108_76724.json
@@ -16,7 +16,7 @@
 		{
 			"version": "8.20",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4108/76724%20-%20Plug-in%202-Outlet%20Switch,%201%20Controlled,%20800S/8.20/ZWN4108_Jasco_76724_8.20.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4108/76724%20-%20Plug-in%202-Outlet%20Switch%2C%201%20Controlled%2C%20800S/8.20/ZWN4108_Jasco_76724_8.20.gbl",
 			"integrity": "sha256:2ed579bb0e05b4d6d9c75a407c3bfc2e7748829bdaa88d92391a7031fc05b4c5"
 		}
 	]

--- a/firmwares/jasco/ZWN4108_76724.json
+++ b/firmwares/jasco/ZWN4108_76724.json
@@ -10,10 +10,6 @@
 	],
 	"upgrades": [
 		{
-			"version": "8.10",
-			"changelog": "Original Release Firmware"
-		},
-		{
 			"version": "8.20",
 			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4108/76724%20-%20Plug-in%202-Outlet%20Switch%2C%201%20Controlled%2C%20800S/8.20/ZWN4108_Jasco_76724_8.20.gbl",

--- a/firmwares/jasco/ZWN4108_76724.json
+++ b/firmwares/jasco/ZWN4108_76724.json
@@ -1,0 +1,23 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWN4108 / 76724",
+			"manufacturerId": "0x0063",
+			"productType": "0x5052",
+			"productId": "0x3137"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.10",
+			"changelog": "1. Original Release Firmware"
+		},
+		{
+			"version": "8.20",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4108/76724%20-%20Plug-in%202-Outlet%20Switch,%201%20Controlled,%20800S/8.20/ZWN4108_Jasco_76724_8.20.gbl",
+			"integrity": "sha256:2ed579bb0e05b4d6d9c75a407c3bfc2e7748829bdaa88d92391a7031fc05b4c5"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN4109_79244.json
+++ b/firmwares/jasco/ZWN4109_79244.json
@@ -10,10 +10,6 @@
 	],
 	"upgrades": [
 		{
-			"version": "8.10",
-			"changelog": "Original Release Firmware"
-		},
-		{
 			"version": "8.20",
 			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4109/79244%20-%20Plug-in%201-Outlet%20Switch%2C%20800S/8.20/ZWN4109_Jasco_79244_8.20.gbl",

--- a/firmwares/jasco/ZWN4109_79244.json
+++ b/firmwares/jasco/ZWN4109_79244.json
@@ -16,7 +16,7 @@
 		{
 			"version": "8.20",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4109/79244%20-%20Plug-in%201-Outlet%20Switch,%20800S/8.20/ZWN4109_Jasco_79244_8.20.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4109/79244%20-%20Plug-in%201-Outlet%20Switch%2C%20800S/8.20/ZWN4109_Jasco_79244_8.20.gbl",
 			"integrity": "sha256:ef864a21fbbbcb7495eb24ed2e15e55cc097e84d6295a62eed816cc56f94c170"
 		}
 	]

--- a/firmwares/jasco/ZWN4109_79244.json
+++ b/firmwares/jasco/ZWN4109_79244.json
@@ -11,11 +11,11 @@
 	"upgrades": [
 		{
 			"version": "8.10",
-			"changelog": "1. Original Release Firmware"
+			"changelog": "Original Release Firmware"
 		},
 		{
 			"version": "8.20",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4109/79244%20-%20Plug-in%201-Outlet%20Switch%2C%20800S/8.20/ZWN4109_Jasco_79244_8.20.gbl",
 			"integrity": "sha256:ef864a21fbbbcb7495eb24ed2e15e55cc097e84d6295a62eed816cc56f94c170"
 		}

--- a/firmwares/jasco/ZWN4109_79244.json
+++ b/firmwares/jasco/ZWN4109_79244.json
@@ -1,0 +1,23 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWN4109 / 79244",
+			"manufacturerId": "0x0063",
+			"productType": "0x5052",
+			"productId": "0x3139"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.10",
+			"changelog": "1. Original Release Firmware"
+		},
+		{
+			"version": "8.20",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4109/79244%20-%20Plug-in%201-Outlet%20Switch,%20800S/8.20/ZWN4109_Jasco_79244_8.20.gbl",
+			"integrity": "sha256:ef864a21fbbbcb7495eb24ed2e15e55cc097e84d6295a62eed816cc56f94c170"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN4204_76722.json
+++ b/firmwares/jasco/ZWN4204_76722.json
@@ -1,0 +1,23 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWN4204 / 76722",
+			"manufacturerId": "0x0063",
+			"productType": "0x4F50",
+			"productId": "0x3039"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.10",
+			"changelog": "1. Original Release Firmware"
+		},
+		{
+			"version": "8.20",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4204/76722%20-%20Plug-in%20Outdoor%20Switch,%20800S/8.20/ZWN4204_Jasco_76722_8.20.gbl",
+			"integrity": "sha256:f27e2ffa2f9497ad4286e0a8c144c3c8375ca223b0c1072ee1b1a990da664e1d"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN4204_76722.json
+++ b/firmwares/jasco/ZWN4204_76722.json
@@ -16,7 +16,7 @@
 		{
 			"version": "8.20",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN4204/76722%20-%20Plug-in%20Outdoor%20Switch,%20800S/8.20/ZWN4204_Jasco_76722_8.20.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4204/76722%20-%20Plug-in%20Outdoor%20Switch%2C%20800S/8.20/ZWN4204_Jasco_76722_8.20.gbl",
 			"integrity": "sha256:f27e2ffa2f9497ad4286e0a8c144c3c8375ca223b0c1072ee1b1a990da664e1d"
 		}
 	]

--- a/firmwares/jasco/ZWN4204_76722.json
+++ b/firmwares/jasco/ZWN4204_76722.json
@@ -11,11 +11,11 @@
 	"upgrades": [
 		{
 			"version": "8.10",
-			"changelog": "1. Original Release Firmware"
+			"changelog": "Original Release Firmware"
 		},
 		{
 			"version": "8.20",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN4204/76722%20-%20Plug-in%20Outdoor%20Switch%2C%20800S/8.20/ZWN4204_Jasco_76722_8.20.gbl",
 			"integrity": "sha256:f27e2ffa2f9497ad4286e0a8c144c3c8375ca223b0c1072ee1b1a990da664e1d"
 		}

--- a/firmwares/jasco/ZWN4204_76722.json
+++ b/firmwares/jasco/ZWN4204_76722.json
@@ -4,15 +4,11 @@
 			"brand": "Jasco",
 			"model": "ZWN4204 / 76722",
 			"manufacturerId": "0x0063",
-			"productType": "0x4F50",
+			"productType": "0x4f50",
 			"productId": "0x3039"
 		}
 	],
 	"upgrades": [
-		{
-			"version": "8.10",
-			"changelog": "Original Release Firmware"
-		},
 		{
 			"version": "8.20",
 			"changelog": "Fixes latching issue",

--- a/firmwares/jasco/ZWN6310_81018.json
+++ b/firmwares/jasco/ZWN6310_81018.json
@@ -1,0 +1,23 @@
+{
+	"devices": [
+		{
+			"brand": "Jasco",
+			"model": "ZWN6310 / 81018",
+			"manufacturerId": "0x0063",
+			"productType": "0x4953",
+			"productId": "0x3433"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.10",
+			"changelog": "1. Original Release Firmware"
+		},
+		{
+			"version": "8.20",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN6310/81018%20-%20Water%20Leak%20Sensor,%20800S/8.20/ZWN6310_Jasco_81018_8.20.gbl",
+			"integrity": "sha256:b81ae9c6d8a1e1674cca65c18446c0ca849c1f5132be8cb0773e5e0c423159b0"
+		}
+	]
+}

--- a/firmwares/jasco/ZWN6310_81018.json
+++ b/firmwares/jasco/ZWN6310_81018.json
@@ -11,11 +11,11 @@
 	"upgrades": [
 		{
 			"version": "8.10",
-			"changelog": "1. Original Release Firmware"
+			"changelog": "Original Release Firmware"
 		},
 		{
 			"version": "8.20",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN6310/81018%20-%20Water%20Leak%20Sensor%2C%20800S/8.20/ZWN6310_Jasco_81018_8.20.gbl",
 			"integrity": "sha256:b81ae9c6d8a1e1674cca65c18446c0ca849c1f5132be8cb0773e5e0c423159b0"
 		}

--- a/firmwares/jasco/ZWN6310_81018.json
+++ b/firmwares/jasco/ZWN6310_81018.json
@@ -10,10 +10,6 @@
 	],
 	"upgrades": [
 		{
-			"version": "8.10",
-			"changelog": "Original Release Firmware"
-		},
-		{
 			"version": "8.20",
 			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN6310/81018%20-%20Water%20Leak%20Sensor%2C%20800S/8.20/ZWN6310_Jasco_81018_8.20.gbl",

--- a/firmwares/jasco/ZWN6310_81018.json
+++ b/firmwares/jasco/ZWN6310_81018.json
@@ -16,7 +16,7 @@
 		{
 			"version": "8.20",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/Jasco/ZWN6310/81018%20-%20Water%20Leak%20Sensor,%20800S/8.20/ZWN6310_Jasco_81018_8.20.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/Jasco/ZWN6310/81018%20-%20Water%20Leak%20Sensor%2C%20800S/8.20/ZWN6310_Jasco_81018_8.20.gbl",
 			"integrity": "sha256:b81ae9c6d8a1e1674cca65c18446c0ca849c1f5132be8cb0773e5e0c423159b0"
 		}
 	]

--- a/firmwares/ultrapro/ZWA3016_59350.json
+++ b/firmwares/ultrapro/ZWA3016_59350.json
@@ -1,0 +1,31 @@
+{
+	"devices": [
+		{
+			"brand": "UltraPro",
+			"model": "ZWA3016 / 59350",
+			"manufacturerId": "0x0063",
+			"productType": "0x4944",
+			"productId": "0x3433"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.23",
+			"changelog": "1. Original Release Firmware",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.23/ZWA3016_UltraPro_59350_1.23.gbl",
+			"integrity": "sha256:80108bfa78b3b30bb34bc3b5866b74231c42d33cf0ae876a26cd28b04f3094a4"
+		},
+		{
+			"version": "1.24",
+			"changelog": "1. Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.24/ZWA3016_UltraPro_59350_1.24.gbl",
+			"integrity": "sha256:430bb1602a2dad55588af1505a7abc609c17bad5bb5f2860ec75f3b231cc1537"
+		},
+		{
+			"version": "1.25",
+			"changelog": "1. Shortened dimming speed from 1-100 to 10 seconds\n2. Updated to ignore invalid zero value for parameters 30, 31, 34, 35 and 36",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.25/ZWA3016_UltraPro_59350_1.25.gbl",
+			"integrity": "sha256:3b5990d4dfb929bdc6078f3d82a779cb87a358ebc9d99e6b0f02e52a25200759"
+		}
+	]
+}

--- a/firmwares/ultrapro/ZWA3016_59350.json
+++ b/firmwares/ultrapro/ZWA3016_59350.json
@@ -12,19 +12,19 @@
 		{
 			"version": "1.23",
 			"changelog": "1. Original Release Firmware",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.23/ZWA3016_UltraPro_59350_1.23.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.23/ZWA3016_UltraPro_59350_1.23.gbl",
 			"integrity": "sha256:80108bfa78b3b30bb34bc3b5866b74231c42d33cf0ae876a26cd28b04f3094a4"
 		},
 		{
 			"version": "1.24",
 			"changelog": "1. Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.24/ZWA3016_UltraPro_59350_1.24.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.24/ZWA3016_UltraPro_59350_1.24.gbl",
 			"integrity": "sha256:430bb1602a2dad55588af1505a7abc609c17bad5bb5f2860ec75f3b231cc1537"
 		},
 		{
 			"version": "1.25",
 			"changelog": "1. Shortened dimming speed from 1-100 to 10 seconds\n2. Updated to ignore invalid zero value for parameters 30, 31, 34, 35 and 36",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer,%20700S/1.25/ZWA3016_UltraPro_59350_1.25.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.25/ZWA3016_UltraPro_59350_1.25.gbl",
 			"integrity": "sha256:3b5990d4dfb929bdc6078f3d82a779cb87a358ebc9d99e6b0f02e52a25200759"
 		}
 	]

--- a/firmwares/ultrapro/ZWA3016_59350.json
+++ b/firmwares/ultrapro/ZWA3016_59350.json
@@ -11,13 +11,13 @@
 	"upgrades": [
 		{
 			"version": "1.23",
-			"changelog": "1. Original Release Firmware",
+			"changelog": "Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.23/ZWA3016_UltraPro_59350_1.23.gbl",
 			"integrity": "sha256:80108bfa78b3b30bb34bc3b5866b74231c42d33cf0ae876a26cd28b04f3094a4"
 		},
 		{
 			"version": "1.24",
-			"changelog": "1. Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
+			"changelog": "Added 0.5s delay to dimming process to fix flashing occuring at the end of max brightness ramp",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWA3016/59350%20-%20In-Wall%20Paddle%20Dimmer%2C%20700S/1.24/ZWA3016_UltraPro_59350_1.24.gbl",
 			"integrity": "sha256:430bb1602a2dad55588af1505a7abc609c17bad5bb5f2860ec75f3b231cc1537"
 		},

--- a/firmwares/ultrapro/ZWA4011_59347.json
+++ b/firmwares/ultrapro/ZWA4011_59347.json
@@ -12,7 +12,7 @@
 		{
 			"version": "1.22",
 			"changelog": "1. Original Release Firmware",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA4011/59347%20-%20In-Wall%20Paddle%20Switch,%20700S/1.22/ZWA4011_UltraPro_59347_1.22.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWA4011/59347%20-%20In-Wall%20Paddle%20Switch%2C%20700S/1.22/ZWA4011_UltraPro_59347_1.22.gbl",
 			"integrity": "sha256:211d1473cc6d2cc8d917a979aa33e380b0c4c2ef4ad91abc2139991859dc6a87"
 		}
 	]

--- a/firmwares/ultrapro/ZWA4011_59347.json
+++ b/firmwares/ultrapro/ZWA4011_59347.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "1.22",
-			"changelog": "1. Original Release Firmware",
+			"changelog": "Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWA4011/59347%20-%20In-Wall%20Paddle%20Switch%2C%20700S/1.22/ZWA4011_UltraPro_59347_1.22.gbl",
 			"integrity": "sha256:211d1473cc6d2cc8d917a979aa33e380b0c4c2ef4ad91abc2139991859dc6a87"
 		}

--- a/firmwares/ultrapro/ZWA4011_59347.json
+++ b/firmwares/ultrapro/ZWA4011_59347.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "UltraPro",
+			"model": "ZWA4011 / 59347",
+			"manufacturerId": "0x0063",
+			"productType": "0x4952",
+			"productId": "0x3333"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.22",
+			"changelog": "1. Original Release Firmware",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA4011/59347%20-%20In-Wall%20Paddle%20Switch,%20700S/1.22/ZWA4011_UltraPro_59347_1.22.gbl",
+			"integrity": "sha256:211d1473cc6d2cc8d917a979aa33e380b0c4c2ef4ad91abc2139991859dc6a87"
+		}
+	]
+}

--- a/firmwares/ultrapro/ZWA4012_59368.json
+++ b/firmwares/ultrapro/ZWA4012_59368.json
@@ -12,7 +12,7 @@
 		{
 			"version": "1.22",
 			"changelog": "1. Original Release Firmware",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA4012/59368%20-%20In-Wall%20Toggle%20Switch,%20700S/1.22/ZWA4012_UltraPro_59368_1.22.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWA4012/59368%20-%20In-Wall%20Toggle%20Switch%2C%20700S/1.22/ZWA4012_UltraPro_59368_1.22.gbl",
 			"integrity": "sha256:b37c262525fb2b97fc67406c4e497c01cb6525635662c86f8dd853fd20bbb067"
 		}
 	]

--- a/firmwares/ultrapro/ZWA4012_59368.json
+++ b/firmwares/ultrapro/ZWA4012_59368.json
@@ -11,7 +11,7 @@
 	"upgrades": [
 		{
 			"version": "1.22",
-			"changelog": "1. Original Release Firmware",
+			"changelog": "Original Release Firmware",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWA4012/59368%20-%20In-Wall%20Toggle%20Switch%2C%20700S/1.22/ZWA4012_UltraPro_59368_1.22.gbl",
 			"integrity": "sha256:b37c262525fb2b97fc67406c4e497c01cb6525635662c86f8dd853fd20bbb067"
 		}

--- a/firmwares/ultrapro/ZWA4012_59368.json
+++ b/firmwares/ultrapro/ZWA4012_59368.json
@@ -1,0 +1,19 @@
+{
+	"devices": [
+		{
+			"brand": "UltraPro",
+			"model": "ZWA4012 / 59368",
+			"manufacturerId": "0x0063",
+			"productType": "0x4952",
+			"productId": "0x3334"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "1.22",
+			"changelog": "1. Original Release Firmware",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWA4012/59368%20-%20In-Wall%20Toggle%20Switch,%20700S/1.22/ZWA4012_UltraPro_59368_1.22.gbl",
+			"integrity": "sha256:b37c262525fb2b97fc67406c4e497c01cb6525635662c86f8dd853fd20bbb067"
+		}
+	]
+}

--- a/firmwares/ultrapro/ZWN3020_76602.json
+++ b/firmwares/ultrapro/ZWN3020_76602.json
@@ -2,7 +2,7 @@
 	"devices": [
 		{
 			"brand": "UltraPro",
-			"model": "ZWA4013 / 58446",
+			"model": "ZWN3020 / 76602",
 			"manufacturerId": "0x0063",
 			"productType": "0x4944",
 			"productId": "0x3432"
@@ -16,7 +16,7 @@
 		{
 			"version": "8.20",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWN3020/76602%20-%20In-Wall%20Paddle%20Dimmer,%20800S/8.20/ZWN3020_UltraPro_76602_8.20.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWN3020/76602%20-%20In-Wall%20Paddle%20Dimmer%2C%20800S/8.20/ZWN3020_UltraPro_76602_8.20.gbl",
 			"integrity": "sha256:6dadc2c05f39618f055c96e8ca118fbc76c520e0c473f88f260286e3ef04e852"
 		}
 	]

--- a/firmwares/ultrapro/ZWN3020_76602.json
+++ b/firmwares/ultrapro/ZWN3020_76602.json
@@ -1,0 +1,23 @@
+{
+	"devices": [
+		{
+			"brand": "UltraPro",
+			"model": "ZWA4013 / 58446",
+			"manufacturerId": "0x0063",
+			"productType": "0x4944",
+			"productId": "0x3432"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.10",
+			"changelog": "1. Original Release Firmware"
+		},
+		{
+			"version": "8.20",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWN3020/76602%20-%20In-Wall%20Paddle%20Dimmer,%20800S/8.20/ZWN3020_UltraPro_76602_8.20.gbl",
+			"integrity": "sha256:6dadc2c05f39618f055c96e8ca118fbc76c520e0c473f88f260286e3ef04e852"
+		}
+	]
+}

--- a/firmwares/ultrapro/ZWN3020_76602.json
+++ b/firmwares/ultrapro/ZWN3020_76602.json
@@ -10,10 +10,6 @@
 	],
 	"upgrades": [
 		{
-			"version": "8.10",
-			"changelog": "Original Release Firmware"
-		},
-		{
 			"version": "8.20",
 			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWN3020/76602%20-%20In-Wall%20Paddle%20Dimmer%2C%20800S/8.20/ZWN3020_UltraPro_76602_8.20.gbl",

--- a/firmwares/ultrapro/ZWN3020_76602.json
+++ b/firmwares/ultrapro/ZWN3020_76602.json
@@ -11,11 +11,11 @@
 	"upgrades": [
 		{
 			"version": "8.10",
-			"changelog": "1. Original Release Firmware"
+			"changelog": "Original Release Firmware"
 		},
 		{
 			"version": "8.20",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWN3020/76602%20-%20In-Wall%20Paddle%20Dimmer%2C%20800S/8.20/ZWN3020_UltraPro_76602_8.20.gbl",
 			"integrity": "sha256:6dadc2c05f39618f055c96e8ca118fbc76c520e0c473f88f260286e3ef04e852"
 		}

--- a/firmwares/ultrapro/ZWN4017_76601.json
+++ b/firmwares/ultrapro/ZWN4017_76601.json
@@ -11,11 +11,11 @@
 	"upgrades": [
 		{
 			"version": "8.10",
-			"changelog": "1. Original Release Firmware"
+			"changelog": "Original Release Firmware"
 		},
 		{
 			"version": "8.20",
-			"changelog": "1. Fixes latching issue",
+			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWN4017/76601%20-%20In-Wall%20Paddle%20Switch%2C%20800S/8.20/ZWN4017_UltraPro_76601_8.20.gbl",
 			"integrity": "sha256:cc3dbd7ff6517d29b0aee39c363753728c8fbcd9e87d126c4b2cf5510659a940"
 		}

--- a/firmwares/ultrapro/ZWN4017_76601.json
+++ b/firmwares/ultrapro/ZWN4017_76601.json
@@ -10,10 +10,6 @@
 	],
 	"upgrades": [
 		{
-			"version": "8.10",
-			"changelog": "Original Release Firmware"
-		},
-		{
 			"version": "8.20",
 			"changelog": "Fixes latching issue",
 			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWN4017/76601%20-%20In-Wall%20Paddle%20Switch%2C%20800S/8.20/ZWN4017_UltraPro_76601_8.20.gbl",

--- a/firmwares/ultrapro/ZWN4017_76601.json
+++ b/firmwares/ultrapro/ZWN4017_76601.json
@@ -16,7 +16,7 @@
 		{
 			"version": "8.20",
 			"changelog": "1. Fixes latching issue",
-			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWN4017/76601%20-%20In-Wall%20Paddle%20Switch,%20800S/8.20/ZWN4017_UltraPro_76601_8.20.gbl",
+			"url": "https://raw.githubusercontent.com/jascoproducts/firmware/bd8e69acc98518f13e49fdf85e38c454e88c334e/zwave/UltraPro/ZWN4017/76601%20-%20In-Wall%20Paddle%20Switch%2C%20800S/8.20/ZWN4017_UltraPro_76601_8.20.gbl",
 			"integrity": "sha256:cc3dbd7ff6517d29b0aee39c363753728c8fbcd9e87d126c4b2cf5510659a940"
 		}
 	]

--- a/firmwares/ultrapro/ZWN4017_76601.json
+++ b/firmwares/ultrapro/ZWN4017_76601.json
@@ -1,0 +1,23 @@
+{
+	"devices": [
+		{
+			"brand": "UltraPro",
+			"model": "ZWN4017 / 76601",
+			"manufacturerId": "0x0063",
+			"productType": "0x4952",
+			"productId": "0x3534"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.10",
+			"changelog": "1. Original Release Firmware"
+		},
+		{
+			"version": "8.20",
+			"changelog": "1. Fixes latching issue",
+			"url": "https://github.com/jascoproducts/firmware/raw/refs/heads/main/zwave/UltraPro/ZWN4017/76601%20-%20In-Wall%20Paddle%20Switch,%20800S/8.20/ZWN4017_UltraPro_76601_8.20.gbl",
+			"integrity": "sha256:cc3dbd7ff6517d29b0aee39c363753728c8fbcd9e87d126c4b2cf5510659a940"
+		}
+	]
+}


### PR DESCRIPTION
Added Devices and updates for the following Jasco and UltraPro devices from the Jasco firmware Github repository:

Jasco
- ZW4006_24770
- ZWA1003_59387
- ZWA3016_59383
- ZWA3017_59384
- ZWA4011_59381
- ZWA4012_59382
- ZWN3018_76597
- ZWN3019_76599
- ZWN3109_76723
- ZWN4015_76598
- ZWN4016_76798
- ZWN4108_76724
- ZWN4109_79244
- ZWN4204_76722
- ZWN6310_81018

Ultrapro
- ZWA3016_59350
- ZWA4011_59347
- ZWA4012_59368
- ZWN3020_76602
- ZWN4017_76601