### PR TITLE
Add Zooz ZSE50-V01-800-LR, US and EU, firmware 1.40

### DIFF
--- a/firmwares/zooz/ZSE50-V01-800-LR.json
+++ b/firmwares/zooz/ZSE50-V01-800-LR.json
@@ -14,6 +14,20 @@
 	],
 	"upgrades": [
 		{
+			"version": "1.40.0",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 1.0, 1.10, 1.20, 1.30, 1.40.\n* Potential Fix: Improved the audio file indexing process after audio updates. This addresses a potential issue where the ZSE50 could produce brief (1-2 second) random noise during playback while scanning the duration of updated audio files in the background. Once the indexing process is complete, the unwanted noise should no longer occur.",
+			"url": "https://www.getzooz.com/firmware/ZSE50_V01R40_US.gbl",
+			"integrity": "sha256:fe90b39eca48e432671ad226011f7406f5fdb3eef8fb7f6550a0e8da9454e42f"
+		},
+		{
+			"version": "1.40.0",
+			"region": "europe",
+			"changelog": "* Includes firmware versions: 1.0, 1.10, 1.20, 1.30, 1.40.\n* Potential Fix: Improved the audio file indexing process after audio updates. This addresses a potential issue where the ZSE50 could produce brief (1-2 second) random noise during playback while scanning the duration of updated audio files in the background. Once the indexing process is complete, the unwanted noise should no longer occur.",
+			"url": "https://www.getzooz.com/firmware/ZSE50_V01R40_EU.gbl",
+			"integrity": "sha256:ec58f1c761b7593e2ca6d8a9fbf34ead70664f5fa73fac9a09b8272a8add17a0"
+		},
+		{
 			"version": "1.30.0",
 			"region": "usa",
 			"changelog": "* Includes firmware versions: 1.0, 1.10, 1.20, 1.30.\n* Fixed an issue with Parameter 1, Value 4: When Playback Mode was set to Value 4 (No sound, LED indicator only), the siren speaker produced an unintended background feedback/humming noise.\n* Fixed an issue with Parameter 14 not being applied during hub or scene control. Parameter 14 now correctly controls both the alarm LED brightness and the device status indicator brightness in all activation methods.\n* Fixed an incorrect voice prompt: Corrected the voice prompt played during network setup failure.\n* Updated SDK from 7.18.8 to 7.24.1.",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->