### PR TITLE
Add Zooz ZEN15-V02 firmware 2.40, ZEN15-V20-EU firmware 20.40

### DIFF
--- a/firmwares/zooz/ZEN15-V02.json
+++ b/firmwares/zooz/ZEN15-V02.json
@@ -14,6 +14,13 @@
 	],
 	"upgrades": [
 		{
+			"version": "2.40.0",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30, 2.40\n* Fixed: Resolved an issue where the Auto-Off timer could turn the ZEN15 off prematurely if a new Z-Wave command was received before the original countdown had expired. The timer now resets correctly whenever the relay state is updated.\n* Improved: Added a filtering algorithm to eliminate false current reports caused by tiny parasitic currents from devices in standby mode. These insignificant currents are now filtered out and no longer reported as actual power consumption.",
+			"url": "https://www.getzooz.com/firmware/ZEN15_V02R40_US.gbl",
+			"integrity": "sha256:ca148bcfa90086d6e9a561da30cceefd58121ddb7c7bc69725be68e7722e0f95"
+		},
+		{
 			"version": "2.30.0",
 			"region": "usa",
 			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30\n* Fixed kWh Reporting Issue: Resolved an edge-case issue where ZEN15 could report inflated kWh values. The root cause was identified as the power metering chip not being properly cleared after an abnormal device restart.\n* Updated Factory Reset Behavior: Improved the factory reset procedure to ensure kWh data is fully cleared. After holding the button for 20 seconds, ZEN15 will now restore default settings and reset accumulated kWh values.\n* Optimized Power Report Frequency (Parameter 171): Changed the default value of Parameter 171 (Power Report Frequency) from 30 seconds to 300 seconds to reduce unnecessary traffic on the Z-Wave network.\n\t* Devices using the previous default value (30 seconds) will be automatically updated to 300 seconds.\n\t* Devices with a custom value configured will remain unchanged.",

--- a/firmwares/zooz/ZEN15-V20-EU.json
+++ b/firmwares/zooz/ZEN15-V20-EU.json
@@ -14,6 +14,13 @@
 	],
 	"upgrades": [
 		{
+			"version": "20.40.0",
+			"region": "europe",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30, 2.40\n* Fixed: Resolved an issue where the Auto-Off timer could turn the ZEN15 off prematurely if a new Z-Wave command was received before the original countdown had expired. The timer now resets correctly whenever the relay state is updated.\n* Improved: Added a filtering algorithm to eliminate false current reports caused by tiny parasitic currents from devices in standby mode. These insignificant currents are now filtered out and no longer reported as actual power consumption.",
+			"url": "https://www.getzooz.com/firmware/ZEN15_V020R40_EU.gbl",
+			"integrity": "sha256:922a448f0733fb92d4e88ed1c168ee6053ac81ff62093b8d68e7c081b63d89be"
+		},
+		{
 			"version": "20.30.0",
 			"region": "europe",
 			"changelog": "* Includes firmware versions: 20.10, 20.20, 2.30\n* Fixed kWh Reporting Issue: Resolved an edge-case issue where ZEN15 could report inflated kWh values. The root cause was identified as the power metering chip not being properly cleared after an abnormal device restart.\n* Updated Factory Reset Behavior: Improved the factory reset procedure to ensure kWh data is fully cleared. After holding the button for 20 seconds, ZEN15 will now restore default settings and reset accumulated kWh values.\n* Optimized Power Report Frequency (Parameter 171): Changed the default value of Parameter 171 (Power Report Frequency) from 30 seconds to 300 seconds to reduce unnecessary traffic on the Z-Wave network.\n\t* Devices using the previous default value (30 seconds) will be automatically updated to 300 seconds.\n\t* Devices with a custom value configured will remain unchanged.",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->