### PR TITLE
Add Zooz ZEN04-800, US, firmware 2.60

### DIFF
--- a/firmwares/zooz/ZEN04-800.json
+++ b/firmwares/zooz/ZEN04-800.json
@@ -14,6 +14,13 @@
 	],
 	"upgrades": [
 		{
+			"version": "2.60.0",
+			"region": "usa",
+			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30, 2.40, 2.50, 2.60.\n* Added new parameter 16 - Disable Manual Control.",
+			"url": "https://www.getzooz.com/firmware/ZEN04_V02R60.gbl",
+			"integrity": "sha256:e27aed07333f236d2ec7ee2769f3d7bb13b1a4cb9899ee2de530b9017c2f81c8"
+		},
+		{
 			"version": "2.50.0",
 			"region": "usa",
 			"changelog": "* Includes firmware versions: 2.0, 2.10, 2.20, 2.30, 2.40, 2.50.\n* Updated SDK from 7.19.3 to 7.24.1.",


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->