### PR TITLE
Fix firmware submission status comment replacement

### DIFF
--- a/.github/scripts/firmware-submission/submission-pr.mts
+++ b/.github/scripts/firmware-submission/submission-pr.mts
@@ -6,14 +6,13 @@ export const SUBMISSION_PR_MARKER = "<!-- firmware-submission-pr -->";
 export const SUBMISSION_COMMENT_TAG = "<!-- firmware-submission-status -->";
 export const SUBMISSION_PR_AUTHOR = "zwave-js-bot";
 
-/** Replace existing bot status comments with one updated comment. */
-export async function replaceExistingStatusComments(
+/** Delete existing status comments posted by the bot on the given issue. */
+export async function deleteExistingStatusComments(
 	octokit: GitHubClient,
 	owner: string,
 	repo: string,
 	issueNumber: number,
-	body: string,
-): Promise<boolean> {
+): Promise<void> {
 	const comments = await octokit.paginate(octokit.rest.issues.listComments, {
 		owner,
 		repo,
@@ -27,41 +26,21 @@ export async function replaceExistingStatusComments(
 	);
 
 	console.log(
-		`Found ${statusComments.length} status comment(s) to replace` +
+		`Found ${statusComments.length} status comment(s) to delete` +
 			` (out of ${comments.length} total).`,
 	);
 
-	if (statusComments.length === 0) {
-		return false;
-	}
-
-	const [newestStatusComment, ...duplicateStatusComments] =
-		statusComments.toSorted(
-			(a, b) => b.created_at.localeCompare(a.created_at) || b.id - a.id,
-		);
-	const taggedBody = `${body}\n${SUBMISSION_COMMENT_TAG}`;
-
-	console.log(`Updating status comment ${newestStatusComment!.id}...`);
-	await octokit.rest.issues.updateComment({
-		owner,
-		repo,
-		comment_id: newestStatusComment!.id,
-		body: taggedBody,
-	});
-
-	for (const comment of duplicateStatusComments) {
-		console.log(`Deleting duplicate status comment ${comment.id}...`);
+	for (const comment of statusComments) {
+		console.log(`Deleting status comment ${comment.id}...`);
 		await octokit.rest.issues.deleteComment({
 			owner,
 			repo,
 			comment_id: comment.id,
 		});
 	}
-
-	return true;
 }
 
-/** Replace the existing status comment or create one when none exists. */
+/** Delete previous status comments and post a fresh one. */
 export async function postStatusComment(
 	octokit: GitHubClient,
 	owner: string,
@@ -69,14 +48,7 @@ export async function postStatusComment(
 	issueNumber: number,
 	body: string,
 ): Promise<void> {
-	const replaced = await replaceExistingStatusComments(
-		octokit,
-		owner,
-		repo,
-		issueNumber,
-		body,
-	);
-	if (replaced) return;
+	await deleteExistingStatusComments(octokit, owner, repo, issueNumber);
 
 	await octokit.rest.issues.createComment({
 		owner,

--- a/.github/scripts/firmware-submission/submission-pr.mts
+++ b/.github/scripts/firmware-submission/submission-pr.mts
@@ -6,17 +6,19 @@ export const SUBMISSION_PR_MARKER = "<!-- firmware-submission-pr -->";
 export const SUBMISSION_COMMENT_TAG = "<!-- firmware-submission-status -->";
 export const SUBMISSION_PR_AUTHOR = "zwave-js-bot";
 
-/** Minimize all existing status comments posted by the bot on the given issue. */
-export async function minimizeExistingStatusComments(
+/** Replace existing bot status comments with one updated comment. */
+export async function replaceExistingStatusComments(
 	octokit: GitHubClient,
 	owner: string,
 	repo: string,
 	issueNumber: number,
-): Promise<void> {
-	const comments = await octokit.paginate(
-		octokit.rest.issues.listComments,
-		{ owner, repo, issue_number: issueNumber },
-	);
+	body: string,
+): Promise<boolean> {
+	const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+		owner,
+		repo,
+		issue_number: issueNumber,
+	});
 
 	const statusComments = comments.filter(
 		(comment) =>
@@ -25,34 +27,41 @@ export async function minimizeExistingStatusComments(
 	);
 
 	console.log(
-		`Found ${statusComments.length} status comment(s) to minimize`
-		+ ` (out of ${comments.length} total).`,
+		`Found ${statusComments.length} status comment(s) to replace` +
+			` (out of ${comments.length} total).`,
 	);
 
-	for (const comment of statusComments) {
-		try {
-			console.log(
-				`Minimizing comment ${comment.id} (node_id: ${comment.node_id})...`,
-			);
-			const result = await octokit.graphql(
-				`mutation($id: ID!) {
-					minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
-						minimizedComment { isMinimized }
-					}
-				}`,
-				{ id: comment.node_id },
-			);
-			console.log("Minimize result:", JSON.stringify(result));
-		} catch (error) {
-			console.log(
-				"Failed to minimize comment:",
-				error instanceof Error ? error.message : String(error),
-			);
-		}
+	if (statusComments.length === 0) {
+		return false;
 	}
+
+	const [newestStatusComment, ...duplicateStatusComments] =
+		statusComments.toSorted(
+			(a, b) => b.created_at.localeCompare(a.created_at) || b.id - a.id,
+		);
+	const taggedBody = `${body}\n${SUBMISSION_COMMENT_TAG}`;
+
+	console.log(`Updating status comment ${newestStatusComment!.id}...`);
+	await octokit.rest.issues.updateComment({
+		owner,
+		repo,
+		comment_id: newestStatusComment!.id,
+		body: taggedBody,
+	});
+
+	for (const comment of duplicateStatusComments) {
+		console.log(`Deleting duplicate status comment ${comment.id}...`);
+		await octokit.rest.issues.deleteComment({
+			owner,
+			repo,
+			comment_id: comment.id,
+		});
+	}
+
+	return true;
 }
 
-/** Delete previous status comments and post a new one. */
+/** Replace the existing status comment or create one when none exists. */
 export async function postStatusComment(
 	octokit: GitHubClient,
 	owner: string,
@@ -60,7 +69,15 @@ export async function postStatusComment(
 	issueNumber: number,
 	body: string,
 ): Promise<void> {
-	await minimizeExistingStatusComments(octokit, owner, repo, issueNumber);
+	const replaced = await replaceExistingStatusComments(
+		octokit,
+		owner,
+		repo,
+		issueNumber,
+		body,
+	);
+	if (replaced) return;
+
 	await octokit.rest.issues.createComment({
 		owner,
 		repo,

--- a/.github/scripts/report-pr-checks.mts
+++ b/.github/scripts/report-pr-checks.mts
@@ -4,6 +4,30 @@ import {
 } from "./firmware-submission/submission-pr.mts";
 import type { GitHubScriptContext } from "./types.mts";
 const SUBMISSION_LABELS = ["processing", "submitted", "checks-failed"];
+const FIRMWARE_DEFINITION_FILE_REGEX = /^firmwares\/[^/]+\/[^/]+\.json$/;
+
+interface PullRequestSource {
+	head?: {
+		repo?: {
+			full_name?: string;
+		} | null;
+	};
+}
+
+export function shouldReportChecksForDirectPR(
+	pr: PullRequestSource,
+	owner: string,
+	repo: string,
+	changedFiles: readonly string[],
+): boolean {
+	return (
+		pr.head?.repo?.full_name != null &&
+		pr.head.repo.full_name !== `${owner}/${repo}` &&
+		changedFiles.some((filename) =>
+			FIRMWARE_DEFINITION_FILE_REGEX.test(filename)
+		)
+	);
+}
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -116,6 +140,28 @@ export default async function main({
 	}
 
 	const issueNumber = getSubmissionIssueNumberFromPR(pr, owner, repo);
+	// Preserve issue-generated submission reporting; scope direct PR comments to external firmware definitions
+	if (issueNumber == null) {
+		const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+			owner,
+			repo,
+			pull_number: prNumber,
+		});
+		if (
+			!shouldReportChecksForDirectPR(
+				pr,
+				owner,
+				repo,
+				changedFiles.map((file) => file.filename),
+			)
+		) {
+			console.log(
+				"PR is not an external firmware definition contribution, skipping",
+			);
+			return;
+		}
+	}
+
 	let labelNames: string[] = [];
 	if (issueNumber != null) {
 		const { data: issue } = await github.rest.issues.get({

--- a/test/firmware-submission-regressions.ts
+++ b/test/firmware-submission-regressions.ts
@@ -189,21 +189,18 @@ type IssueComment = {
 };
 
 function createStatusCommentMock(comments: IssueComment[]) {
-	const updatedComments: { id: number; body: string }[] = [];
 	const deletedCommentIds: number[] = [];
 	const createdBodies: string[] = [];
+	const operations: string[] = [];
 	const issues = {
 		listComments: async () => ({ data: comments }),
-		updateComment: async (
-			{ comment_id, body }: { comment_id: number; body: string },
-		) => {
-			updatedComments.push({ id: comment_id, body });
-		},
 		deleteComment: async ({ comment_id }: { comment_id: number }) => {
 			deletedCommentIds.push(comment_id);
+			operations.push(`delete:${comment_id}`);
 		},
 		createComment: async ({ body }: { body: string }) => {
 			createdBodies.push(body);
+			operations.push("create");
 		},
 	};
 
@@ -212,13 +209,13 @@ function createStatusCommentMock(comments: IssueComment[]) {
 			paginate: async () => comments,
 			rest: { issues },
 		},
-		updatedComments,
 		deletedCommentIds,
 		createdBodies,
+		operations,
 	};
 }
 
-test("postStatusComment updates the newest matching comment and deletes older duplicates", async (t) => {
+test("postStatusComment deletes all matching comments before creating a fresh one", async (t) => {
 	const comments: IssueComment[] = [
 		{
 			id: 1,
@@ -261,11 +258,22 @@ test("postStatusComment updates the newest matching comment and deletes older du
 		"Latest status",
 	);
 
-	t.deepEqual(mock.updatedComments, [
-		{ id: 5, body: `Latest status\n${SUBMISSION_COMMENT_TAG}` },
+	t.deepEqual(mock.deletedCommentIds, [1, 3, 5]);
+	t.deepEqual(
+		comments
+			.filter((comment) => !mock.deletedCommentIds.includes(comment.id))
+			.map((comment) => comment.id),
+		[2, 4],
+	);
+	t.deepEqual(mock.createdBodies, [
+		`Latest status\n${SUBMISSION_COMMENT_TAG}`,
 	]);
-	t.deepEqual(mock.deletedCommentIds, [3, 1]);
-	t.deepEqual(mock.createdBodies, []);
+	t.deepEqual(mock.operations, [
+		"delete:1",
+		"delete:3",
+		"delete:5",
+		"create",
+	]);
 });
 
 test("postStatusComment creates a tagged comment when no matching comment exists", async (t) => {
@@ -292,37 +300,11 @@ test("postStatusComment creates a tagged comment when no matching comment exists
 		"First status",
 	);
 
-	t.deepEqual(mock.updatedComments, []);
 	t.deepEqual(mock.deletedCommentIds, []);
 	t.deepEqual(mock.createdBodies, [
 		`First status\n${SUBMISSION_COMMENT_TAG}`,
 	]);
-});
-
-test("postStatusComment propagates update failures without creating a comment", async (t) => {
-	const mock = createStatusCommentMock([
-		{
-			id: 1,
-			body: `Old status\n${SUBMISSION_COMMENT_TAG}`,
-			created_at: "2026-07-30T10:00:00Z",
-			user: { login: "zwave-js-bot" },
-		},
-	]);
-	mock.octokit.rest.issues.updateComment = async () => {
-		throw new Error("update failed");
-	};
-
-	await t.throwsAsync(
-		postStatusComment(
-			mock.octokit,
-			"zwave-js",
-			"firmware-updates",
-			351,
-			"Latest status",
-		),
-		{ message: "update failed" },
-	);
-	t.deepEqual(mock.createdBodies, []);
+	t.deepEqual(mock.operations, ["create"]);
 });
 
 test("postStatusComment propagates delete failures without creating a comment", async (t) => {
@@ -355,6 +337,7 @@ test("postStatusComment propagates delete failures without creating a comment", 
 		{ message: "delete failed" },
 	);
 	t.deepEqual(mock.createdBodies, []);
+	t.deepEqual(mock.operations, []);
 });
 
 test("parseIssueBody supports multiple-target issue bodies and preserves markdown headings inside textarea fields", (t) => {

--- a/test/firmware-submission-regressions.ts
+++ b/test/firmware-submission-regressions.ts
@@ -5,6 +5,8 @@ import { readFile } from "node:fs/promises";
 const processSubmissionModulePath =
 	"../.github/scripts/firmware-submission/process-submission.mts";
 const reportPrChecksModulePath = "../.github/scripts/report-pr-checks.mts";
+const submissionPrModulePath =
+	"../.github/scripts/firmware-submission/submission-pr.mts";
 const resetOnEditModulePath =
 	"../.github/scripts/firmware-submission/reset-on-edit.mts";
 const cleanupLabelsModulePath =
@@ -12,6 +14,7 @@ const cleanupLabelsModulePath =
 
 const processSubmissionModule = await import(processSubmissionModulePath);
 const reportPrChecksModule = await import(reportPrChecksModulePath);
+const submissionPrModule = await import(submissionPrModulePath);
 const resetOnEditModule = await import(resetOnEditModulePath);
 const cleanupLabelsModule = await import(cleanupLabelsModulePath);
 
@@ -30,6 +33,7 @@ const {
 } = processSubmissionModule;
 const { extractErrorOutput, formatCodeBlock, workflowRunPassed } =
 	reportPrChecksModule;
+const { postStatusComment, SUBMISSION_COMMENT_TAG } = submissionPrModule;
 const resetOnEdit = resetOnEditModule.default;
 const cleanupLabels = cleanupLabelsModule.default;
 
@@ -174,6 +178,184 @@ function createIssuesMock(labels: string[] = []) {
 		addLabelsCalls,
 	};
 }
+
+type IssueComment = {
+	id: number;
+	body: string | null;
+	created_at: string;
+	user: {
+		login: string;
+	} | null;
+};
+
+function createStatusCommentMock(comments: IssueComment[]) {
+	const updatedComments: { id: number; body: string }[] = [];
+	const deletedCommentIds: number[] = [];
+	const createdBodies: string[] = [];
+	const issues = {
+		listComments: async () => ({ data: comments }),
+		updateComment: async (
+			{ comment_id, body }: { comment_id: number; body: string },
+		) => {
+			updatedComments.push({ id: comment_id, body });
+		},
+		deleteComment: async ({ comment_id }: { comment_id: number }) => {
+			deletedCommentIds.push(comment_id);
+		},
+		createComment: async ({ body }: { body: string }) => {
+			createdBodies.push(body);
+		},
+	};
+
+	return {
+		octokit: {
+			paginate: async () => comments,
+			rest: { issues },
+		},
+		updatedComments,
+		deletedCommentIds,
+		createdBodies,
+	};
+}
+
+test("postStatusComment updates the newest matching comment and deletes older duplicates", async (t) => {
+	const comments: IssueComment[] = [
+		{
+			id: 1,
+			body: `Old status\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-27T10:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+		{
+			id: 2,
+			body: `Another bot\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-30T10:00:00Z",
+			user: { login: "other-bot" },
+		},
+		{
+			id: 3,
+			body: `Older status\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-28T10:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+		{
+			id: 4,
+			body: "An unrelated comment",
+			created_at: "2026-07-30T11:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+		{
+			id: 5,
+			body: `Newest status\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-29T10:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+	];
+	const mock = createStatusCommentMock(comments);
+
+	await postStatusComment(
+		mock.octokit,
+		"zwave-js",
+		"firmware-updates",
+		351,
+		"Latest status",
+	);
+
+	t.deepEqual(mock.updatedComments, [
+		{ id: 5, body: `Latest status\n${SUBMISSION_COMMENT_TAG}` },
+	]);
+	t.deepEqual(mock.deletedCommentIds, [3, 1]);
+	t.deepEqual(mock.createdBodies, []);
+});
+
+test("postStatusComment creates a tagged comment when no matching comment exists", async (t) => {
+	const mock = createStatusCommentMock([
+		{
+			id: 1,
+			body: "An unrelated comment",
+			created_at: "2026-07-30T10:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+		{
+			id: 2,
+			body: `Another bot\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-30T11:00:00Z",
+			user: { login: "other-bot" },
+		},
+	]);
+
+	await postStatusComment(
+		mock.octokit,
+		"zwave-js",
+		"firmware-updates",
+		351,
+		"First status",
+	);
+
+	t.deepEqual(mock.updatedComments, []);
+	t.deepEqual(mock.deletedCommentIds, []);
+	t.deepEqual(mock.createdBodies, [
+		`First status\n${SUBMISSION_COMMENT_TAG}`,
+	]);
+});
+
+test("postStatusComment propagates update failures without creating a comment", async (t) => {
+	const mock = createStatusCommentMock([
+		{
+			id: 1,
+			body: `Old status\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-30T10:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+	]);
+	mock.octokit.rest.issues.updateComment = async () => {
+		throw new Error("update failed");
+	};
+
+	await t.throwsAsync(
+		postStatusComment(
+			mock.octokit,
+			"zwave-js",
+			"firmware-updates",
+			351,
+			"Latest status",
+		),
+		{ message: "update failed" },
+	);
+	t.deepEqual(mock.createdBodies, []);
+});
+
+test("postStatusComment propagates delete failures without creating a comment", async (t) => {
+	const mock = createStatusCommentMock([
+		{
+			id: 1,
+			body: `Old status\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-29T10:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+		{
+			id: 2,
+			body: `Newest status\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-30T10:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+	]);
+	mock.octokit.rest.issues.deleteComment = async () => {
+		throw new Error("delete failed");
+	};
+
+	await t.throwsAsync(
+		postStatusComment(
+			mock.octokit,
+			"zwave-js",
+			"firmware-updates",
+			351,
+			"Latest status",
+		),
+		{ message: "delete failed" },
+	);
+	t.deepEqual(mock.createdBodies, []);
+});
 
 test("parseIssueBody supports multiple-target issue bodies and preserves markdown headings inside textarea fields", (t) => {
 	const body = `

--- a/test/firmware-submission-regressions.ts
+++ b/test/firmware-submission-regressions.ts
@@ -31,8 +31,12 @@ const {
 	resolveGitHubFirmwarePermalink,
 	sameExactDeviceSet,
 } = processSubmissionModule;
-const { extractErrorOutput, formatCodeBlock, workflowRunPassed } =
-	reportPrChecksModule;
+const {
+	extractErrorOutput,
+	formatCodeBlock,
+	shouldReportChecksForDirectPR,
+	workflowRunPassed,
+} = reportPrChecksModule;
 const { postStatusComment, SUBMISSION_COMMENT_TAG } = submissionPrModule;
 const resetOnEdit = resetOnEditModule.default;
 const cleanupLabels = cleanupLabelsModule.default;
@@ -1325,6 +1329,57 @@ test("workflowRunPassed only treats successful conclusions as passing", (t) => {
 	t.false(workflowRunPassed("cancelled"));
 	t.false(workflowRunPassed("timed_out"));
 	t.false(workflowRunPassed(null));
+});
+
+test("shouldReportChecksForDirectPR only accepts external firmware definition changes", (t) => {
+	const externalPR = {
+		head: {
+			repo: {
+				full_name: "contributor/firmware-updates",
+			},
+		},
+	};
+	const internalPR = {
+		head: {
+			repo: {
+				full_name: "zwave-js/firmware-updates",
+			},
+		},
+	};
+	const firmwareDefinitionFiles = ["firmwares/Aeotec/ZW189.json"];
+
+	t.true(
+		shouldReportChecksForDirectPR(
+			externalPR,
+			"zwave-js",
+			"firmware-updates",
+			firmwareDefinitionFiles,
+		),
+	);
+	t.false(
+		shouldReportChecksForDirectPR(
+			internalPR,
+			"zwave-js",
+			"firmware-updates",
+			firmwareDefinitionFiles,
+		),
+	);
+	t.false(
+		shouldReportChecksForDirectPR(
+			externalPR,
+			"zwave-js",
+			"firmware-updates",
+			[".github/workflows/report-pr-checks.yml"],
+		),
+	);
+	t.false(
+		shouldReportChecksForDirectPR(
+			externalPR,
+			"zwave-js",
+			"firmware-updates",
+			["firmwares/Aeotec/nested/ZW189.json"],
+		),
+	);
 });
 
 test("extractErrorOutput preserves multiline action errors", (t) => {


### PR DESCRIPTION
Follow-up to #357.

## Summary
- replace GraphQL comment minimization with REST deletion
- delete every tagged bot status comment before posting a fresh result
- leave unrelated issue comments untouched
- propagate deletion failures to prevent duplicate creation
- limit direct PR comments to external contributions that modify `firmwares/<vendor>/*.json`
- preserve reporting on linked issues for bot-generated firmware submissions

## Tests
- `NODE_OPTIONS='--loader=tsx' yarn ava test/firmware-submission-regressions.ts --match='shouldReportChecksForDirectPR*' --match='postStatusComment*'`
- `yarn check`