### PR TITLE
Report direct firmware PR failures only

### DIFF
--- a/.github/scripts/firmware-submission/submission-pr.mts
+++ b/.github/scripts/firmware-submission/submission-pr.mts
@@ -40,15 +40,16 @@ export async function deleteExistingStatusComments(
 	}
 }
 
-/** Delete previous status comments and post a fresh one. */
+/** Delete previous status comments and post a fresh one, or none if `body` is null. */
 export async function postStatusComment(
 	octokit: GitHubClient,
 	owner: string,
 	repo: string,
 	issueNumber: number,
-	body: string,
+	body: string | null,
 ): Promise<void> {
 	await deleteExistingStatusComments(octokit, owner, repo, issueNumber);
+	if (body == null) return;
 
 	await octokit.rest.issues.createComment({
 		owner,

--- a/.github/scripts/report-pr-checks.mts
+++ b/.github/scripts/report-pr-checks.mts
@@ -1,9 +1,8 @@
 import {
-	deleteExistingStatusComments,
 	getSubmissionIssueNumberFromPR,
 	postStatusComment,
 } from "./firmware-submission/submission-pr.mts";
-import type { GitHubClient, GitHubScriptContext } from "./types.mts";
+import type { GitHubScriptContext } from "./types.mts";
 const SUBMISSION_LABELS = ["processing", "submitted", "checks-failed"];
 const FIRMWARE_DEFINITION_FILE_REGEX = /^firmwares\/[^/]+\/[^/]+\.json$/;
 
@@ -84,29 +83,6 @@ export function workflowRunPassed(
 	return conclusion === "success";
 }
 
-export async function publishCheckStatus(
-	github: GitHubClient,
-	owner: string,
-	repo: string,
-	prNumber: number,
-	issueNumber: number | null,
-	passed: boolean,
-	commentBody: string,
-): Promise<void> {
-	const commentTarget = issueNumber ?? prNumber;
-	if (passed && issueNumber == null) {
-		await deleteExistingStatusComments(
-			github,
-			owner,
-			repo,
-			commentTarget,
-		);
-		return;
-	}
-
-	await postStatusComment(github, owner, repo, commentTarget, commentBody);
-}
-
 function shouldIncludeJobInFailureSummary(
 	conclusion: string | null | undefined,
 ): boolean {
@@ -164,8 +140,22 @@ export default async function main({
 	}
 
 	const issueNumber = getSubmissionIssueNumberFromPR(pr, owner, repo);
-	// Preserve issue-generated submission reporting; scope direct PR comments to external firmware definitions
-	if (issueNumber == null) {
+
+	let labelNames: string[] = [];
+	if (issueNumber != null) {
+		const { data: issue } = await github.rest.issues.get({
+			owner,
+			repo,
+			issue_number: issueNumber,
+		});
+		labelNames = issue.labels.map((label) =>
+			typeof label === "string" ? label : (label.name ?? ""),
+		);
+		if (!SUBMISSION_LABELS.some((label) => labelNames.includes(label))) {
+			console.log("Issue does not have a submission label, skipping");
+			return;
+		}
+	} else {
 		const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
 			owner,
 			repo,
@@ -182,22 +172,6 @@ export default async function main({
 			console.log(
 				"PR is not an external firmware definition contribution, skipping",
 			);
-			return;
-		}
-	}
-
-	let labelNames: string[] = [];
-	if (issueNumber != null) {
-		const { data: issue } = await github.rest.issues.get({
-			owner,
-			repo,
-			issue_number: issueNumber,
-		});
-		labelNames = issue.labels.map((label) =>
-			typeof label === "string" ? label : (label.name ?? ""),
-		);
-		if (!SUBMISSION_LABELS.some((label) => labelNames.includes(label))) {
-			console.log("Issue does not have a submission label, skipping");
 			return;
 		}
 	}
@@ -249,14 +223,14 @@ ${errorLines || "(No error output found)"}`;
 		}
 	}
 
-	await publishCheckStatus(
+	// Direct PRs are only commented on while checks fail, so a passing run just
+	// clears the stale comment. Submission issues always get a status comment.
+	await postStatusComment(
 		github,
 		owner,
 		repo,
-		prNumber,
-		issueNumber,
-		passed,
-		commentBody,
+		issueNumber ?? prNumber,
+		issueNumber == null && passed ? null : commentBody,
 	);
 
 	if (issueNumber == null) return;

--- a/.github/scripts/report-pr-checks.mts
+++ b/.github/scripts/report-pr-checks.mts
@@ -1,8 +1,9 @@
 import {
+	deleteExistingStatusComments,
 	getSubmissionIssueNumberFromPR,
 	postStatusComment,
 } from "./firmware-submission/submission-pr.mts";
-import type { GitHubScriptContext } from "./types.mts";
+import type { GitHubClient, GitHubScriptContext } from "./types.mts";
 const SUBMISSION_LABELS = ["processing", "submitted", "checks-failed"];
 const FIRMWARE_DEFINITION_FILE_REGEX = /^firmwares\/[^/]+\/[^/]+\.json$/;
 
@@ -81,6 +82,29 @@ export function workflowRunPassed(
 	conclusion: string | null | undefined,
 ): boolean {
 	return conclusion === "success";
+}
+
+export async function publishCheckStatus(
+	github: GitHubClient,
+	owner: string,
+	repo: string,
+	prNumber: number,
+	issueNumber: number | null,
+	passed: boolean,
+	commentBody: string,
+): Promise<void> {
+	const commentTarget = issueNumber ?? prNumber;
+	if (passed && issueNumber == null) {
+		await deleteExistingStatusComments(
+			github,
+			owner,
+			repo,
+			commentTarget,
+		);
+		return;
+	}
+
+	await postStatusComment(github, owner, repo, commentTarget, commentBody);
 }
 
 function shouldIncludeJobInFailureSummary(
@@ -225,8 +249,15 @@ ${errorLines || "(No error output found)"}`;
 		}
 	}
 
-	const commentTarget = issueNumber ?? prNumber;
-	await postStatusComment(github, owner, repo, commentTarget, commentBody);
+	await publishCheckStatus(
+		github,
+		owner,
+		repo,
+		prNumber,
+		issueNumber,
+		passed,
+		commentBody,
+	);
 
 	if (issueNumber == null) return;
 

--- a/test/firmware-submission-regressions.ts
+++ b/test/firmware-submission-regressions.ts
@@ -34,7 +34,6 @@ const {
 const {
 	extractErrorOutput,
 	formatCodeBlock,
-	publishCheckStatus,
 	shouldReportChecksForDirectPR,
 	workflowRunPassed,
 } = reportPrChecksModule;
@@ -345,7 +344,7 @@ test("postStatusComment propagates delete failures without creating a comment", 
 	t.deepEqual(mock.operations, []);
 });
 
-test("publishCheckStatus posts a fresh failure comment on direct PRs", async (t) => {
+test("postStatusComment removes stale comments without posting when body is null", async (t) => {
 	const mock = createStatusCommentMock([
 		{
 			id: 1,
@@ -355,65 +354,16 @@ test("publishCheckStatus posts a fresh failure comment on direct PRs", async (t)
 		},
 	]);
 
-	await publishCheckStatus(
+	await postStatusComment(
 		mock.octokit,
 		"zwave-js",
 		"firmware-updates",
 		351,
 		null,
-		false,
-		"Latest failure",
-	);
-
-	t.deepEqual(mock.operations, ["delete:1", "create"]);
-	t.deepEqual(mock.createdBodies, [
-		`Latest failure\n${SUBMISSION_COMMENT_TAG}`,
-	]);
-});
-
-test("publishCheckStatus removes stale comments without posting on direct PR success", async (t) => {
-	const mock = createStatusCommentMock([
-		{
-			id: 1,
-			body: `Previous failure\n${SUBMISSION_COMMENT_TAG}`,
-			created_at: "2026-07-30T10:00:00Z",
-			user: { login: "zwave-js-bot" },
-		},
-	]);
-
-	await publishCheckStatus(
-		mock.octokit,
-		"zwave-js",
-		"firmware-updates",
-		351,
-		null,
-		true,
-		"All checks passed",
 	);
 
 	t.deepEqual(mock.operations, ["delete:1"]);
 	t.deepEqual(mock.createdBodies, []);
-});
-
-test("publishCheckStatus posts success comments on submission issues", async (t) => {
-	const mock = createStatusCommentMock([]);
-	const successMessage =
-		"All checks passed on the pull request. A maintainer will review and merge.";
-
-	await publishCheckStatus(
-		mock.octokit,
-		"zwave-js",
-		"firmware-updates",
-		400,
-		351,
-		true,
-		successMessage,
-	);
-
-	t.deepEqual(mock.operations, ["create"]);
-	t.deepEqual(mock.createdBodies, [
-		`${successMessage}\n${SUBMISSION_COMMENT_TAG}`,
-	]);
 });
 
 test("parseIssueBody supports multiple-target issue bodies and preserves markdown headings inside textarea fields", (t) => {

--- a/test/firmware-submission-regressions.ts
+++ b/test/firmware-submission-regressions.ts
@@ -34,6 +34,7 @@ const {
 const {
 	extractErrorOutput,
 	formatCodeBlock,
+	publishCheckStatus,
 	shouldReportChecksForDirectPR,
 	workflowRunPassed,
 } = reportPrChecksModule;
@@ -342,6 +343,77 @@ test("postStatusComment propagates delete failures without creating a comment", 
 	);
 	t.deepEqual(mock.createdBodies, []);
 	t.deepEqual(mock.operations, []);
+});
+
+test("publishCheckStatus posts a fresh failure comment on direct PRs", async (t) => {
+	const mock = createStatusCommentMock([
+		{
+			id: 1,
+			body: `Previous failure\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-30T10:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+	]);
+
+	await publishCheckStatus(
+		mock.octokit,
+		"zwave-js",
+		"firmware-updates",
+		351,
+		null,
+		false,
+		"Latest failure",
+	);
+
+	t.deepEqual(mock.operations, ["delete:1", "create"]);
+	t.deepEqual(mock.createdBodies, [
+		`Latest failure\n${SUBMISSION_COMMENT_TAG}`,
+	]);
+});
+
+test("publishCheckStatus removes stale comments without posting on direct PR success", async (t) => {
+	const mock = createStatusCommentMock([
+		{
+			id: 1,
+			body: `Previous failure\n${SUBMISSION_COMMENT_TAG}`,
+			created_at: "2026-07-30T10:00:00Z",
+			user: { login: "zwave-js-bot" },
+		},
+	]);
+
+	await publishCheckStatus(
+		mock.octokit,
+		"zwave-js",
+		"firmware-updates",
+		351,
+		null,
+		true,
+		"All checks passed",
+	);
+
+	t.deepEqual(mock.operations, ["delete:1"]);
+	t.deepEqual(mock.createdBodies, []);
+});
+
+test("publishCheckStatus posts success comments on submission issues", async (t) => {
+	const mock = createStatusCommentMock([]);
+	const successMessage =
+		"All checks passed on the pull request. A maintainer will review and merge.";
+
+	await publishCheckStatus(
+		mock.octokit,
+		"zwave-js",
+		"firmware-updates",
+		400,
+		351,
+		true,
+		successMessage,
+	);
+
+	t.deepEqual(mock.operations, ["create"]);
+	t.deepEqual(mock.createdBodies, [
+		`${successMessage}\n${SUBMISSION_COMMENT_TAG}`,
+	]);
 });
 
 test("parseIssueBody supports multiple-target issue bodies and preserves markdown headings inside textarea fields", (t) => {


### PR DESCRIPTION
Follow-up to #358.

## Summary
- keep success and failure status comments on linked firmware submission issues
- post status comments on direct external firmware-definition PRs only when checks fail
- delete stale tagged bot comments without creating a replacement when direct PR checks pass
- preserve failure propagation during status cleanup

## Tests
- `NODE_OPTIONS='--loader=tsx' yarn ava test/firmware-submission-regressions.ts`
- `yarn check`