### PR TITLE
Add lamp-zw2 firmware configuration file

### DIFF
--- a/firmwares/versa/lamp-zw2.json
+++ b/firmwares/versa/lamp-zw2.json
@@ -1,0 +1,20 @@
+{
+	"devices": [
+		{
+			"brand": "Versa",
+			"model": "LAMP-ZW2",
+			"manufacturerId": "0x0464",
+			"productType": "0xff00",
+			"productId": "0xff0d"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.10",
+			"changelog": "Latest Versa Firmware",
+			"target": 0,
+			"url": "https://versawireless-my.sharepoint.com/:u:/p/justin/IQDAPu51kE5XQacsKTbLzn2pAQh9xCPMPSA2VMdBNsrYzIw?e=2NYc6c",
+			"integrity": "sha256-5PpvUwIU4DCgzxpOSQ+etKipga+Ng9ZV2bDWwikfbdM="
+		}
+	]
+}


### PR DESCRIPTION
Add lamp-zw2 firmware

<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->