### PR TITLE
Add Versa LAMP-ZW2, firmware 8.10

### DIFF
--- a/firmwares/versa/lamp-zw2.json
+++ b/firmwares/versa/lamp-zw2.json
@@ -1,0 +1,20 @@
+{
+	"devices": [
+		{
+			"brand": "Versa",
+			"model": "LAMP-ZW2",
+			"manufacturerId": "0x0464",
+			"productType": "0xff00",
+			"productId": "0xff0d"
+		}
+	],
+	"upgrades": [
+		{
+			"version": "8.10",
+			"changelog": "Latest Versa Firmware",
+			"target": 0,
+			"url": "https://versawireless-my.sharepoint.com/:u:/p/justin/IQDAPu51kE5XQacsKTbLzn2pAQh9xCPMPSA2VMdBNsrYzIw?e=2NYc6c",
+			"integrity": "sha256-5PpvUwIU4DCgzxpOSQ+etKipga+Ng9ZV2bDWwikfbdM="
+		}
+	]
+}

--- a/firmwares/versa/lamp-zw2.json
+++ b/firmwares/versa/lamp-zw2.json
@@ -13,8 +13,8 @@
 			"version": "8.10",
 			"changelog": "Latest Versa Firmware",
 			"target": 0,
-			"url": "https://versawireless-my.sharepoint.com/:u:/p/justin/IQDAPu51kE5XQacsKTbLzn2pAQh9xCPMPSA2VMdBNsrYzIw?e=2NYc6c",
-			"integrity": "sha256-5PpvUwIU4DCgzxpOSQ+etKipga+Ng9ZV2bDWwikfbdM="
+			"url": "https://github.com/VersaWireless/firmware/releases/download/v8.10.0/LAMP-ZW2_v8.10.0_hw1_US-LR_0464FF00FF0D_2026-01-15.gbl",
+			"integrity": "sha256:e4fa6f530214e030a0cf1a4e490f9eb4a8a981af8d83d655d9b0d6c2291f6dd3"
 		}
 	]
 }

--- a/firmwares/versa/lamp-zw2.json
+++ b/firmwares/versa/lamp-zw2.json
@@ -11,9 +11,9 @@
 	"upgrades": [
 		{
 			"version": "8.10",
-			"changelog": "Latest Versa Firmware",
+			"changelog": "Latest Versa Firmware, updated to Silicon Labs SDK 7.24",
 			"target": 0,
-			"url": "https://github.com/VersaWireless/firmware/releases/download/v8.10.0/LAMP-ZW2_v8.10.0_hw1_US-LR_0464FF00FF0D_2026-01-15.gbl",
+			"url": "https://github.com/versa-wireless/firmware/releases/download/v8.10.0/LAMP-ZW2_v8.10.0_hw1_US-LR_0464FF00FF0D_2026-01-15.gbl",
 			"integrity": "sha256:e4fa6f530214e030a0cf1a4e490f9eb4a8a981af8d83d655d9b0d6c2291f6dd3"
 		}
 	]


### PR DESCRIPTION
<!--
    PLEASE READ THIS if you're not a device manufacturer contributing updates for your devices!

    We **will not** accept firmware updates hosted by third parties. All updates must come from the respective device manufacturer.

    We make an exception for firmwares that are publicly hosted by the manufacturer, but those may still require confirmation the manufacturer's confirmation before merging.
-->