### PR TITLE
Update Inovelli VZW31-SN, firmware 1.4

### DIFF
--- a/firmwares/inovelli/VZW31-SN.json
+++ b/firmwares/inovelli/VZW31-SN.json
@@ -10,7 +10,7 @@
 	],
 	"upgrades": [
 		{
-			"version": "2.2",
+			"version": "2.02",
 			"channel": "beta",
 			"changelog": "- Fixed LED color distortion for some colors at low brightness.\n- Fixed the incorrect mapping of dimming duration (P1-P8).\n- Fixed duration in the Switch Multilevel command.",
 			"files": [
@@ -22,14 +22,14 @@
 			]
 		},
 		{
-			"version": "1.2",
+			"version": "1.04",
 			"channel": "stable",
-			"changelog": "Change default dimming type back to leading edge. Added button combo to switch between leading and trailing edge. Added temperature monitoring feature.",
+			"changelog": "- Added Group 7 for fan control.\n- Added the ability to disable the relay when in OnOff + Full Wave mode.\n- Fixed a situation where a lifeline report was not made when a multicast message was received.\n- Resolved a bug in Association Group Behavior.\n- Upgraded the Z-Wave SDK.",
 			"files": [
 				{
 					"target": 0,
-					"url": "https://github.com/InovelliUSA/Firmware/raw/e1f2999ccb34b058b25228d14eb42b353ee26c39/Red-Series/Z-Wave/VZW31-SN-2-1-Switch/Beta/1.02/VZW31-SN_1.02-Beta.gbl",
-					"integrity": "sha256:107871e6de514afd02bb322e52d9c3341c16e1d5bbe4ae15ad1de5ce6356ab0d"
+					"url": "https://github.com/InovelliUSA/Firmware/raw/9bb2308acd7ccf4cd838dfdb83bb2ea753ca2cf3/Red-Series/Z-Wave/VZW31-SN-2-1-Switch/Production/1.04/VZW31-SN_1.04.gbl",
+					"integrity": "sha256:6cc54dbbc6768678a4f23ead1c00b03ee9334c5836bd01ded9f190d521a3fd6c"
 				}
 			]
 		}

--- a/firmwares/inovelli/VZW31-SN.json
+++ b/firmwares/inovelli/VZW31-SN.json
@@ -10,7 +10,7 @@
 	],
 	"upgrades": [
 		{
-			"version": "2.02",
+			"version": "2.2",
 			"channel": "beta",
 			"changelog": "- Fixed LED color distortion for some colors at low brightness.\n- Fixed the incorrect mapping of dimming duration (P1-P8).\n- Fixed duration in the Switch Multilevel command.",
 			"files": [
@@ -22,7 +22,7 @@
 			]
 		},
 		{
-			"version": "1.04",
+			"version": "1.4",
 			"channel": "stable",
 			"changelog": "- Added Group 7 for fan control.\n- Added the ability to disable the relay when in OnOff + Full Wave mode.\n- Fixed a situation where a lifeline report was not made when a multicast message was received.\n- Resolved a bug in Association Group Behavior.\n- Upgraded the Z-Wave SDK.",
 			"files": [

--- a/firmwares/inovelli/VZW32-SN.json
+++ b/firmwares/inovelli/VZW32-SN.json
@@ -10,7 +10,7 @@
 	],
 	"upgrades": [
 		{
-			"version": "2.3",
+			"version": "2.03",
 			"channel": "beta",
 			"changelog": "- Fixed an issue where the P20 could not restore its default settings.\n- Changed the default value of P50 (Button Delay) to 3.\n- Optimized the network re-connection logic.\n- Further optimized the interaction logic between the mmWave module and the Z-Wave chip.\n- Optimized the processing logic of the metering module.",
 			"files": [
@@ -22,7 +22,7 @@
 			]
 		},
 		{
-			"version": "2.2",
+			"version": "2.02",
 			"channel": "stable",
 			"changelog": "- Optimized the interaction logic between the switch and the mmWave module.\n- Fixed the incorrect use of duration in the SwitchMultilevel Set command.\n- When the switch is restarted, P240 will be reported to indicate that the switch has been restarted.",
 			"files": [

--- a/firmwares/inovelli/VZW32-SN.json
+++ b/firmwares/inovelli/VZW32-SN.json
@@ -10,7 +10,7 @@
 	],
 	"upgrades": [
 		{
-			"version": "2.03",
+			"version": "2.3",
 			"channel": "beta",
 			"changelog": "- Fixed an issue where the P20 could not restore its default settings.\n- Changed the default value of P50 (Button Delay) to 3.\n- Optimized the network re-connection logic.\n- Further optimized the interaction logic between the mmWave module and the Z-Wave chip.\n- Optimized the processing logic of the metering module.",
 			"files": [
@@ -22,7 +22,7 @@
 			]
 		},
 		{
-			"version": "2.02",
+			"version": "2.2",
 			"channel": "stable",
 			"changelog": "- Optimized the interaction logic between the switch and the mmWave module.\n- Fixed the incorrect use of duration in the SwitchMultilevel Set command.\n- When the switch is restarted, P240 will be reported to indicate that the switch has been restarted.",
 			"files": [


### PR DESCRIPTION
Not sure why or how, but the version numbers are broken. Possibly on other devices as well, but I only checked these two because I have them. Additionally, for VZW31-SN the stable version was incorrectly pointed to the device beta path. Additionally, additionally, I moved the VZW31-SN stable version to the latest _actually existent_ prod firmware. ~I'll nudge a LLM to check the other Inovelli devices for similar issues, but for now~ I've identified, fixed, reviewed, and submitted for these two devices.

Changes:
- VZW31-SN: fix stable entry that pointed to a nonexistent Beta/1.02 file; point to the current production firmware 1.04 with the correct changelog and integrity hash (URL pinned to the commit SHA). Changelog notes sourced from https://help.inovelli.com/en/articles/8505159-red-series-dimmer-switch-firmware-changelog
- VZW31-SN / VZW32-SN: correct label versions to use actual firmware versions (2.02/2.03) instead of possibly "truncated" forms (2.2/2.3).

Verifiable by checking the official Inovelli Repo
https://github.com/InovelliUSA/Firmware/tree/main/Red-Series/Z-Wave/VZW31-SN-2-1-Switch
https://github.com/InovelliUSA/Firmware/tree/main/Red-Series/Z-Wave/VZW32-SN-MMWave-Switch


I withdraw my offer to look at the other devices. Inovelli is a bit inconsistent. Case in point:
`https://raw.githubusercontent.com/InovelliUSA/Firmware/ec05e86280e6d6632537346c744584c3c135e5e2/Red-Series/Z-Wave/LZW60-4-1-Sensor/Production/2.40/LZW60_2.4-Production.otz`
Is it 2.4 or 2.40? *facepalm*